### PR TITLE
Fixed db-reset task on Windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,8 +142,12 @@ module.exports = function(grunt) {
         var done;
 
         done = this.async();
+        var cmd = process.platform === "win32"
+            ? "NODE_ENV=" + finalEnv + " & "
+            : "NODE_ENV=" + finalEnv + " ";
+            
         exec(
-            "NODE_ENV=" + finalEnv + " node artifacts/db-reset.js",
+            cmd + "node artifacts/db-reset.js",
             function(err, stdout, stderr) {
                 if (err) {
                     grunt.log.error("db-reset:");


### PR DESCRIPTION
grunt db-reset:development did not work on Windows 8.1, because cmd.exe has special syntax to run multiple commands and set environment variables. I fixed this problem. The code was tested on Windows 8.1 and node 0.12.0