### PR TITLE
Run NodeGoat on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:0.12-onbuild
+
+ONBUILD RUN grunt db-reset:development

--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ grunt db-reset:development
 ```
 npm start
 ```
+
+### OPTION 3 - Run NodeGoat on Docker
+
+**You need to install [docker](https://docs.docker.com/installation/) and [docker compose](https://docs.docker.com/compose/install/) to be able to use this option**
+
+The repo includes the Dockerfile and docker-compose.yml necessary to setup the app and the db instance then connect them together.
+
+* Build the images:
+```
+docker-compose build
+```
+* Run the app:
+```
+docker-compose up
+```
+
+
 #### Customizing the Default Application Configuration
 The default application settings (database url, http port, etc.) can be changed by updating the [config file] (https://github.com/OWASP/NodejsGoat/blob/master/config/env/all.js).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+web:
+  build: .
+  command: npm start
+  ports:
+    - "4000:4000"
+  links:
+    - mongo
+mongo:
+  image: mongo:latest
+  expose:
+    - "27017"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
Fixes OWASP/NodeGoat#53

Little PR with a docker-compose configuration.
Using a mongo container linked to a node based container containing the vulnerable app.