### PR TITLE
Docker as non root user. docker-compose build now succeeds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
 FROM node:4.4
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-COPY package.json /usr/src/app/
+ENV user nodegoat_docker
+ENV workdir /usr/src/app/
+
+RUN useradd --create-home --system --shell /bin/false nodegoat_docker_compose
+
+# Home is required for npm install. System account with no ability to login to shell
+RUN useradd --create-home --system --shell /bin/false $user
+
+RUN mkdir -p $workdir
+WORKDIR $workdir
+COPY package.json $workdir
+
+# chown is required by npm install.
+RUN chown $user --recursive $workdir
+# Then all further actions including running the containers should be done under non-root user.
+USER $user
+
 RUN npm install
-COPY . /usr/src/app/
+COPY . $workdir
 
 # Neither of the following work, because the mongo container isn't yet running.
 #RUN node artifacts/db-reset.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV workdir /usr/src/app/
 # Home is required for npm install. System account with no ability to login to shell
 RUN useradd --create-home --system --shell /bin/false $user
 
-RUN mkdir -p $workdir
+RUN mkdir --parents $workdir
 WORKDIR $workdir
 COPY package.json $workdir
 
@@ -18,7 +18,7 @@ USER $user
 RUN npm install
 COPY . $workdir
 
-# Permissions need to be reaplied, due to how docker applies root to new files.
+# Permissions need to be reapplied, due to how docker applies root to new files.
 USER root
 RUN chown $user:$user --recursive $workdir
 RUN chmod --recursive o-wrx $workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM node:4.4
 ENV user nodegoat_docker
 ENV workdir /usr/src/app/
 
-RUN useradd --create-home --system --shell /bin/false nodegoat_docker_compose
-
 # Home is required for npm install. System account with no ability to login to shell
 RUN useradd --create-home --system --shell /bin/false $user
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
       - mongo
   mongo:
     image: mongo:latest
+    user: mongodb
     expose:
       - "27017"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "async": "^2.0.0-rc.4",
-    "grunt": "^1.0.1",
+    "grunt": "~0.4.5",
     "grunt-cli": "^1.2.0",
     "grunt-concurrent": "^2.3.0",
     "grunt-contrib-jshint": "^1.0.0",


### PR DESCRIPTION
This is a fix so that Docker doesn't run all commands and the container as root. @Pamplemousse : your feedback on this would be good also.

This also includes the temporary downgrade fix for #77 

