### PR TITLE
Fix typo in the tutorial

### DIFF
--- a/app/views/tutorial/a6.html
+++ b/app/views/tutorial/a6.html
@@ -75,7 +75,7 @@ https.createServer(httpsOptions, app).listen(config.port, function() {
                     3. The insecure demo application stores users personal sensitive information in plain text. To fix it, The
                     <code>data/profile-dao.js</code>can be modified to use crypto module to encrypt and decrypt sensitive information as below:
                     <pre>
-// Include crtpto module
+// Include crypto module
 var crypto = require("crypto");
 
 //Set keys config object


### PR DESCRIPTION
I found a typo when reading through the tutorial:

crtpto -> crypto