### PR TITLE
Changed test value for Bank Routing due to new feature #84 breaking it

### DIFF
--- a/test/security/profile-test.js
+++ b/test/security/profile-test.js
@@ -74,7 +74,7 @@ test.before(function() {
     webDriver.findElement(By.name("ssn")).sendKeys("seleniumSSN");
     webDriver.findElement(By.name("dob")).sendKeys("12/23/5678");
     webDriver.findElement(By.name("bankAcc")).sendKeys("seleniumBankAcc");
-    webDriver.findElement(By.name("bankRouting")).sendKeys("seleniumBankRouting");
+    webDriver.findElement(By.name("bankRouting")).sendKeys("0198212#");
     webDriver.findElement(By.name("address")).sendKeys("seleniumAddress");
     webDriver.findElement(By.name("submit")).click();
     webDriver.sleep(1000);
@@ -211,7 +211,7 @@ test.describe(zapTargetAppRoute + " regression test suite", function() {
                     false,
                     "",
                     "POST",
-                    "firstName=JohnseleniumJohn&lastName=DoeseleniumDoe&ssn=seleniumSSN&dob=12/23/5678&bankAcc=seleniumBankAcc&bankRouting=seleniumBankRouting&address=seleniumAddress&_csrf=&submit=",
+                    "firstName=JohnseleniumJohn&lastName=DoeseleniumDoe&ssn=seleniumSSN&dob=12/23/5678&bankAcc=seleniumBankAcc&bankRouting=0198212#&address=seleniumAddress&_csrf=&submit=",
                     zapApiKey,
                     function(err, resp) {
                         var statusValue;


### PR DESCRIPTION
Pays to run tests before commiting. By default, there are usually 10 failing tests in security regression testing. 3 are false alarms, 7 are from the input fields on the profile route. With the new ReDoS regex validation none fail, because selenium can't warm up Zap due to failing the initial post. Once I fixed the initial post to accommodate the new ReDoS feature, What we tell the Zap API also needed to be changed. Once all this is done, We get 9 defects (3 false positives, 6 defective input fields), so we're one down, so the [training video](https://www.youtube.com/watch?v=DrwXUOJWMoo&feature=youtu.be) is no longer correct Just as well I checked this, as I'm using this [here](http://www.devseccon.com/asia-2017/session/developing-a-high-performance-security-focussed-agile-team-2-hour-workshop/) next week.