### PR TITLE
Adding an npm run-script for the database seeding task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,7 +165,7 @@ module.exports = function(grunt) {
     grunt.option("force", true);
 
     grunt.registerTask("db-reset", "(Re)init the database.", function(arg) {
-        var finalEnv = arg || "development";
+        var finalEnv = process.env.NODE_ENV || arg || "development";
         var done;
 
         done = this.async();

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm install
 * Populate MongoDB with seed data required for the app
     * Run grunt task below to populate the DB with seed data required for the application. Pass the desired environment as argument. If not passed, "development" is the default:
 ```
-grunt db-reset:development
+npm run db:seed
 ```
 * Start server, this starts the NodeGoat application at url [http://localhost:4000/](http://localhost:4000/)
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm install
         * Update the `db` property in file `config/env/development.js` to reflect your DB setup. (in format: `mongodb://localhost:27017/<databasename>`)
 
 * Populate MongoDB with seed data required for the app
-    * Run grunt task below to populate the DB with seed data required for the application. Pass the desired environment as argument. If not passed, "development" is the default:
+    * Run the npm-script below to populate the DB with seed data required for the application. Pass the desired environment as argument. If not passed, "development" is the default:
 ```
 npm run db:seed
 ```
@@ -104,7 +104,7 @@ You can also open an issue, sending a PR, or get in touch on [Gitter Chat](https
 
 If sending PR, once code is ready to commit, run:
 ```
-grunt precommit
+npm run precommit
 ```
 This command uses `js-beautifier` to indent the code and verifies these [coding standards](https://github.com/OWASP/NodeGoat/blob/master/.jshintrc) using `jsHint`. Please resolve all `jsHint` errors before committing the code.
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "node node_modules/grunt-cli/bin/grunt test",
-    "db:seed": "grunt db-reset:development"
+    "db:seed": "grunt db-reset:development",
+    "precommit": "grunt precommit"
   },
   "devDependencies": {
     "async": "^2.0.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "scripts": {
     "start": "node server.js",
     "test": "node node_modules/grunt-cli/bin/grunt test",
-    "db:reset": "grunt db-reset",
     "db:seed": "grunt db-reset:development"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "node node_modules/grunt-cli/bin/grunt test",
+    "db:reset": "grunt db-reset",
     "db:seed": "grunt db-reset:development"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "scripts": {
     "start": "node server.js",
-    "test": "node node_modules/grunt-cli/bin/grunt test"
+    "test": "node node_modules/grunt-cli/bin/grunt test",
+    "db:seed": "grunt db-reset:development"
   },
   "devDependencies": {
     "async": "^2.0.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "node node_modules/grunt-cli/bin/grunt test",
-    "db:seed": "grunt db-reset:development",
+    "db:seed": "grunt db-reset",
     "precommit": "grunt precommit"
   },
   "devDependencies": {


### PR DESCRIPTION
I keep going back to the docs for the exact grunt task to run to populate the database.
How about we add this as a simple npm run-script, where someone can just do:

```bash
npm run db:seed
```

and it would run the grunt task?

* If you like it I'll be happy to update the README
* We can also change the npm script name to something simpler like 'npm run db' and that's it.