### PR TITLE
Update tutorial and comments for A6 to match Node.js best practices

### DIFF
--- a/app/data/profile-dao.js
+++ b/app/data/profile-dao.js
@@ -24,7 +24,7 @@ function ProfileDAO(db) {
         // create a random salt for the PBKDF2 function - 16 bytes is the minimum length according to NIST
         var salt = crypto.randomBytes(16);
         return crypto.pbkdf2Sync(config.cryptoKey, salt, 100000, 512, "sha512");
-    }
+    };
 
     // Helper methods to encryt / decrypt
     var encrypt = function(toEncrypt) {

--- a/app/data/profile-dao.js
+++ b/app/data/profile-dao.js
@@ -23,7 +23,7 @@ function ProfileDAO(db) {
     var createIV = function() {
         // create a random salt for the PBKDF2 function - 16 bytes is the minimum length according to NIST
         var salt = crypto.randomBytes(16);
-        return crypto.pbkdf2Sync(config.cryptoKey, salt, 100000, 512, 'sha512');
+        return crypto.pbkdf2Sync(config.cryptoKey, salt, 100000, 512, "sha512");
     }
 
     // Helper methods to encryt / decrypt
@@ -98,7 +98,7 @@ function ProfileDAO(db) {
             function(err, user) {
                 if (err) return callback(err, null);
                 /*
-                // Fix for A7 - Sensitive Data Exposure
+                // Fix for A6 - Sensitive Data Exposure
                 // Decrypt ssn and DOB values to display to user
                 user.ssn = user.ssn ? decrypt(user.ssn) : "";
                 user.dob = user.dob ? decrypt(user.dob) : "";

--- a/app/data/profile-dao.js
+++ b/app/data/profile-dao.js
@@ -18,18 +18,25 @@ function ProfileDAO(db) {
     var crypto = require("crypto");
     var config = require("../../config/config");
 
-    // Helper function to encrypt data
+    /// Helper method create initialization vector
+    // By default the initialization vector is not secure enough, so we create our own
+    var createIV = function() {
+        // create a random salt for the PBKDF2 function - 16 bytes is the minimum length according to NIST
+        var salt = crypto.randomBytes(16);
+        return crypto.pbkdf2Sync(config.cryptoKey, salt, 100000, 512, 'sha512');
+    }
+
+    // Helper methods to encryt / decrypt
     var encrypt = function(toEncrypt) {
-        var cipher = crypto.createCipher(config.cryptoAlgo, config.cryptoKey);
+        config.iv = createIV();
+        var cipher = crypto.createCipheriv(config.cryptoAlgo, config.cryptoKey, config.iv);
         return cipher.update(toEncrypt, "utf8", "hex") + cipher.final("hex");
     };
 
-    // Helper function to decrypt data
     var decrypt = function(toDecrypt) {
-        var decipher = crypto.createDecipher(config.cryptoAlgo, config.cryptoKey);
+        var decipher = crypto.createDecipheriv(config.cryptoAlgo, config.cryptoKey, config.iv);
         return decipher.update(toDecrypt, "hex", "utf8") + decipher.final("utf8");
     };
-
     */
 
     this.updateUser = function(userId, firstName, lastName, ssn, dob, address, bankAcc, bankRouting, callback) {

--- a/app/views/tutorial/a2.html
+++ b/app/views/tutorial/a2.html
@@ -247,7 +247,6 @@ req.session.destroy(function() {
                         <p>
                             <ul>
                                 <li>For additional protection against brute forcing, enforce account disabling after an established number of invalid login attempts (e.g., five attempts is common). The account must be disabled for a period of time sufficient to discourage brute force guessing of credentials, but not so long as to allow for a denial-of-service attack to be performed.</li>
-                                <li>Authentication failure responses should not indicate which part of the authentication data was incorrect. For example, instead of "Invalid username" or "Invalid password", just use "Invalid username and/or password" for both. Error responses must be truly identical in both display and source code</li>
                                 <li>Only send non-temporary passwords over an encrypted connection or as encrypted data, such as in an encrypted email. Temporary passwords associated with email resets may be an exception. Enforce the changing of temporary passwords on the next use. Temporary passwords and links should have a short expiration time.</li>
                             </ul>
                     </div>

--- a/app/views/tutorial/a6.html
+++ b/app/views/tutorial/a6.html
@@ -91,7 +91,7 @@ var createIV = function() {
     // create a random salt for the PBKDF2 function - 16 bytes is the minimum length according to NIST
     var salt = crypto.randomBytes(16);
     return crypto.pbkdf2Sync(config.cryptoKey, salt, 100000, 512, "sha512");
-}
+};
 
 // Helper methods to encryt / decrypt
 var encrypt = function(toEncrypt) {

--- a/app/views/tutorial/a6.html
+++ b/app/views/tutorial/a6.html
@@ -90,7 +90,7 @@ var config = {
 var createIV = function() {
     // create a random salt for the PBKDF2 function - 16 bytes is the minimum length according to NIST
     var salt = crypto.randomBytes(16);
-    return crypto.pbkdf2Sync(config.cryptoKey, salt, 100000, 512, 'sha512');
+    return crypto.pbkdf2Sync(config.cryptoKey, salt, 100000, 512, "sha512");
 }
 
 // Helper methods to encryt / decrypt

--- a/app/views/tutorial/a6.html
+++ b/app/views/tutorial/a6.html
@@ -81,17 +81,27 @@ var crypto = require("crypto");
 //Set keys config object
 var config = {
     cryptoKey: "a_secure_key_for_crypto_here",
-    cryptoAlgo: "aes256" // or other secure encryption algo here
+    cryptoAlgo: "aes256", // or other secure encryption algo here
+    iv: ""
 };
+
+// Helper method create initialization vector
+// By default the initialization vector is not secure enough, so we create our own
+var createIV = function() {
+    // create a random salt for the PBKDF2 function - 16 bytes is the minimum length according to NIST
+    var salt = crypto.randomBytes(16);
+    return crypto.pbkdf2Sync(config.cryptoKey, salt, 100000, 512, 'sha512');
+}
 
 // Helper methods to encryt / decrypt
 var encrypt = function(toEncrypt) {
-    var cipher = crypto.createCipher(config.cryptoAlgo, config.cryptoKey);
+    config.iv = createIV();
+    var cipher = crypto.createCipheriv(config.cryptoAlgo, config.cryptoKey, config.iv);
     return cipher.update(toEncrypt, "utf8", "hex") + cipher.final("hex");
 };
 
 var decrypt = function(toDecrypt) {
-    var decipher = crypto.createDecipher(config.cryptoAlgo, config.cryptoKey);
+    var decipher = crypto.createDecipheriv(config.cryptoAlgo, config.cryptoKey, config.iv);
     return decipher.update(toDecrypt, "hex", "utf8") + decipher.final("utf8");
 };
 


### PR DESCRIPTION
According to [Node's Crypto API docs](https://nodejs.org/api/crypto.html#crypto_crypto_createcipher_algorithm_password_options), the default initialization vector used by the createCipher function is not random enough to protect against brute-force attacks. This code change updates the tutorial and comments for A6 to provide guidance on how to create a properly random IV for use in the AES256 algorithm.