### PR TITLE
feat(xss-context): add example for context sensitive XSS encoding issues

### DIFF
--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,4 +1,5 @@
 var ProfileDAO = require("../data/profile-dao").ProfileDAO;
+var ESAPI = require('node-esapi')
 
 /* The ProfileHandler must be constructed with a connected db */
 function ProfileHandler(db) {
@@ -6,18 +7,29 @@ function ProfileHandler(db) {
 
     var profile = new ProfileDAO(db);
 
-    this.displayProfile = function(req, res, next) {
+    this.displayProfile = function (req, res, next) {
         var userId = req.session.userId;
 
-        profile.getByUserId(parseInt(userId), function(err, doc) {
+
+
+        profile.getByUserId(parseInt(userId), function (err, doc) {
             if (err) return next(err);
             doc.userId = userId;
+
+            // @TODO @FIXME
+            // while the developer intentions were correct in encoding the user supplied input so it
+            // doesn't end up as an XSS attack, the context is incorrect as it is encoding the firstname for HTML
+            // while this same variable is also used in the context of a URL link element
+            doc.firstNameSafeString = ESAPI.encoder().encodeForHTML(doc.firstName)
+            // fix it by replacing the above with another template variable that is used for 
+            // the context of a URL in a link header
+            // doc.firstNameSafeString = ESAPI.encoder().encodeForURL(urlInput)
 
             return res.render("profile", doc);
         });
     };
 
-    this.handleProfileUpdate = function(req, res, next) {
+    this.handleProfileUpdate = function (req, res, next) {
 
         var firstName = req.body.firstName;
         var lastName = req.body.lastName;
@@ -55,7 +67,7 @@ function ProfileHandler(db) {
             address,
             bankAcc,
             bankRouting,
-            function(err, user) {
+            function (err, user) {
 
                 if (err) return next(err);
 

--- a/app/views/profile.html
+++ b/app/views/profile.html
@@ -38,7 +38,7 @@
                 <form role="form" method="post" action="/profile">
                     <div class="form-group">
                         <label for="firstName">First Name</label>
-                        <input type="text" class="form-control" id="firstName" name="firstName" value="{{firstName}}" placeholder="Enter first name">
+                        <input type="text" class="form-control" id="firstName" name="firstName" value="{{firstNameSafeString}}" placeholder="Enter first name">
                     </div>
                     <div class="form-group">
                         <label for="lastName">Last Name</label>
@@ -68,7 +68,7 @@
                     <input type="hidden" name="_csrf" value="{{csrftoken}}" />
                     <button type="submit" class="btn btn-default" name="submit">Submit</button>
 
-                    <a href="{{firstName}}">Google search this profile by name</a>
+                    <a href="{{firstNameSafeString}}">Google search this profile by name</a>
                 </form>
             </div>
         </div>

--- a/app/views/profile.html
+++ b/app/views/profile.html
@@ -67,6 +67,8 @@
                     </div>
                     <input type="hidden" name="_csrf" value="{{csrftoken}}" />
                     <button type="submit" class="btn btn-default" name="submit">Submit</button>
+
+                    <a href="{{firstName}}">Google search this profile by name</a>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
Adding a case where we use the same variable as a URL for a hyperlink. While the variable is encoded for HTML for the input element, it isn't suitable for the URL entry.

<img width="540" alt="owasp node js goat project context sensitive xss" src="https://user-images.githubusercontent.com/316371/45256990-1fd89c80-b3a7-11e8-829c-30ca21506fc7.png">
