### PR TITLE
Switch to multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+docker-compose.yml
+.dockerignore
+.git
+.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,12 @@ version: "2.0"
 services:
   web:
     build: .
-    command: bash -c "node artifacts/db-reset.js && npm start"
+    command: sh -c "until nc -z -w 2 mongo 27017 && echo 'mongo is ready for connections' && node artifacts/db-reset.js && npm start; do sleep 2; done"
     ports:
       - "4000:4000"
-    links:
-      - mongo
+
   mongo:
     image: mongo:latest
     user: mongodb
     expose:
-      - "27017"
+      - 27017


### PR DESCRIPTION
- Dockerfile updated to use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).
- Unnecessary commands in Dockerfile removed.
- NodeGoat image size reduced from 951 MB to 97.4 MB by using `node:4-alpine`
> If the image is affecting the project let me know so i can revert it to `node:4.4` as the version of node:4-alpine currently is 4.9.1 and the version of node:4.4 is 4.4.7 however i did not consider it a problem as the documentation says: requires Node v4.4 or above
- Removed `links` from docker-compose.yml as by default the 2 services will be linked with the network that will be created when you run `docker-compose up`