### PR TITLE
Improve performance of docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ ENV USER node
 ENV WORKDIR /home/$USER/app
 WORKDIR $WORKDIR
 COPY --from=0 /usr/src/app/node_modules node_modules
-COPY . $WORKDIR
-# chown is required to run the project with a non-root user
-RUN chown -R $USER:$USER /home/$USER && chmod -R g-s /home/$USER && chmod -R o-wrx $WORKDIR
+RUN chown $USER:$USER $WORKDIR
+COPY --chown=node . $WORKDIR
+# In production environment uncomment the next line
+#RUN chown -R $USER:$USER /home/$USER && chmod -R g-s /home/$USER && chmod -R o-wrx $WORKDIR
 # Then all further actions including running the containers should be done under non-root user.
 USER $USER
 EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=0 /usr/src/app/node_modules node_modules
 RUN chown $USER:$USER $WORKDIR
 COPY --chown=node . $WORKDIR
 # In production environment uncomment the next line
-#RUN chown -R $USER:$USER /home/$USER && chmod -R g-s /home/$USER && chmod -R o-wrx $WORKDIR
+#RUN chown -R $USER:$USER /home/$USER && chmod -R g-s,o-rx /home/$USER && chmod -R o-wrx $WORKDIR
 # Then all further actions including running the containers should be done under non-root user.
 USER $USER
 EXPOSE 4000


### PR DESCRIPTION
Running the following command before the image is built and more importantly after any app code change has occurred results in a long wait (minutes):

```
RUN chown -R $USER:$USER /home/$USER && chmod -R g-s /home/$USER && chmod -R o-wrx $WORKDIR
```

This is a suggested compromise. Running the existing `COPY` command but with `--chown` as a flag is many times faster (seconds vs minutes) than doing the same with an added `RUN chown`, in saying that, the `chmod`s are no longer executed.

If/when someone wants to run NodeGoat in production, which may not be very likely, and if they do, and want to go the extra mile, the following line can be uncommented:

```
RUN chown -R $USER:$USER /home/$USER && chmod -R g-s /home/$USER && chmod -R o-wrx $WORKDIR
```

&nbsp;

Comments, suggested improvements?
