### PR TITLE
Remove caret on needle dependency (^2.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "helmet": "^2.0.0",
     "marked": "0.3.9",
     "mongodb": "^2.1.18",
-    "needle": "^2.2.4",
+    "needle": "2.2.4",
     "node-esapi": "0.0.1",
     "serve-favicon": "^2.3.0",
     "swig": "^1.4.2",


### PR DESCRIPTION
Very recently the `needle` dependency released a breaking change resulting in a failed build for the web app through the docker setup.

Short error:
```
web_1    | > owasp-nodejs-goat@1.3.0 start /home/node/app
web_1    | > node server.js
web_1    | /home/node/app/node_modules/needle/node_modules/debug/src/node.js:132
web_1    |     let val = process.env[key];
web_1    |     ^^^
web_1    | SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
web_1    |     at Object.<anonymous> (/home/node/app/node_modules/needle/lib/needle.js:13:19)
``` 

Caused by the needle dependcy@2.3.0 which is installed by `^2.2.4`
https://www.npmjs.com/package/needle