### PR TITLE
Migration to node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 services:
   - docker
 node_js:
+  - v8
+  - v10
   - v12
 
 ## Cache NPM folder and Cypress binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.4
+FROM node:12.7.0
 ENV WORKDIR /usr/src/app/
 WORKDIR $WORKDIR
 COPY package*.json $WORKDIR

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This Heroku instance uses Free ($0/month) node server and MongoLab add-on.
 ### OPTION 2 - Run NodeGoat on your machine
 
 If you do not wish to run NodeGoat on Heroku, please follow these steps to setup and run it locally -
-* Install [Node.js](http://nodejs.org/) - NodeGoat requires Node v4.4 or above
+* Install [Node.js](http://nodejs.org/) - NodeGoat requires Node v8 or above
 
 * Clone the github repository
 ```


### PR DESCRIPTION
### Context:
Original issue: #150 
Release Target: 1.5

- [x] Add support for Node 12
- [x] Add support for Node 10
- [x] Add support for Node 8
- [x] Update `travis.yaml` with the builds for those environments
- [x] Update the `readme.md` with the relevant info

### Changelog
- https://github.com/OWASP/NodeGoat/commit/1ff89cb6a44c0c5cd3e9d4683b63c8746fbedd93 Added Node v8 and v10 to Travis
- https://github.com/OWASP/NodeGoat/commit/1ff89cb6a44c0c5cd3e9d4683b63c8746fbedd93 Update references in doc
- https://github.com/OWASP/NodeGoat/pull/160/commits/ae31b3e7126f2a215a33d75bbdf296bba11d6750 Dockerfile upgraded to Node v12