### PR TITLE
fix: startup logs stringified objects incorrectly

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,5 +1,6 @@
 const _ = require("underscore");
 const path = require("path");
+const util = require('util')
 
 const finalEnv = process.env.NODE_ENV || "development";
 
@@ -8,6 +9,7 @@ const envConf = require(path.resolve(__dirname + "/../config/env/" + finalEnv.to
 
 const config = { ...allConf, ...envConf }
 
-console.log(`Current Config: ${config}`)
+console.log(`Current Config:`)
+console.log(util.inspect(config, false, null))
 
 module.exports = config;

--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ MongoClient.connect(db, (err, db) => {
         console.log(err);
         process.exit(1);
     }
-    console.log(`Connected to the database: ${db}`);
+    console.log(`Connected to the database`);
 
     /*
     // Fix for A5 - Security MisConfig


### PR DESCRIPTION
# Why this PR

Startup console logs printed objects improperly.

## Before

When starting up, console printed:

```
Current Config: [object Object]
Connected to the database: [object Object]
Express http server listening on port 5000
```


## After

With this PR startup logs prints:

```
Current Config:
{
  port: '5000',
  db: 'mongodb://localhost:27017/nodegoat',
  cookieSecret: 'session_cookie_secret_key_here',
  cryptoKey: 'a_secure_key_for_crypto_here',
  cryptoAlgo: 'aes256',
  hostName: 'localhost',
  zapHostName: '192.168.56.20',
  zapPort: '8080',
  zapApiKey: '1234',
  zapApiFeedbackSpeed: 5000
}
Connected to the database
Express http server listening on port 5000
```

* Nothing in particular to print for the database object.