### PR TITLE
fix: example of xss in bad context using a dedicated profile field

### DIFF
--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -20,10 +20,10 @@ function ProfileHandler (db) {
             // while the developer intentions were correct in encoding the user supplied input so it
             // doesn't end up as an XSS attack, the context is incorrect as it is encoding the firstname for HTML
             // while this same variable is also used in the context of a URL link element
-            doc.firstNameSafeString = ESAPI.encoder().encodeForHTML(doc.firstName)
+            doc.website = ESAPI.encoder().encodeForHTML(doc.website)
             // fix it by replacing the above with another template variable that is used for 
             // the context of a URL in a link header
-            // doc.doc.firstNameSafeURLString = ESAPI.encoder().encodeForURL(urlInput)
+            // doc.website = ESAPI.encoder().encodeForURL(doc.website)
 
             return res.render("profile", doc);
         });

--- a/app/views/profile.html
+++ b/app/views/profile.html
@@ -65,6 +65,11 @@
                         <label for="address">Address</label>
                         <input type="text" class="form-control" id="address" name="address" value="{{address}}" placeholder="Enter address">
                     </div>
+                    <div class="form-group">
+                        <label for="website">Website</label>
+                        <input type="text" class="form-control" id="website" name="website" value="{{website}}"
+                            placeholder="https://">
+                    </div>
                     <input type="hidden" name="_csrf" value="{{csrftoken}}" />
                     <button type="submit" class="btn btn-default" name="submit">Submit</button>
 


### PR DESCRIPTION
# Why this PR

The example of using proper context to perform output encoding is incorrect in terms of bad code, and example reference:
* bad code: line 26 of profile.js referenced a `doc.doc.firstName..` but `doc.doc` is incorrect and never really did work anyway. Also the `firstNameSafeString` template variable in the view at `profile.html` was never assigned.
* example reference: the example relied on the firstName with an attempt to first encode it, and then the `FIXME` hint to encode it properly for HTML but the problem is that even if you encode it (either way), it still causes an XSS because other views use it, such as the drop-down profile name etc.

## This change

This PR fixes the issue by introducing another profile field `website` that is never used anywhere, and can be mitigated easily with encoding, but if done improperly can still introduce an XSS, and the `FIXME` clause of proper context encoding then makes sense.