### PR TITLE
Restore A9 vulnerability

### DIFF
--- a/apps/server-render/package-lock.json
+++ b/apps/server-render/package-lock.json
@@ -4827,9 +4827,9 @@
       }
     },
     "marked": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
-      "integrity": "sha1-VM5qV+cgw6xgmDdOxiX8vMl/8pA="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
+      "integrity": "sha1-QROhWsXXvKFYpargciRYe5+hW5Q="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/apps/server-render/package.json
+++ b/apps/server-render/package.json
@@ -14,7 +14,7 @@
     "express-session": "^1.13.0",
     "forever": "^3.0.0",
     "helmet": "^2.0.0",
-    "marked": "0.3.9",
+    "marked": "0.3.5",
     "mongodb": "^2.1.18",
     "needle": "2.2.4",
     "node-esapi": "0.0.1",
@@ -23,7 +23,7 @@
     "underscore": "^1.8.3"
   },
   "comments": {
-    "//": "a9 insecure components"
+    "//": "do not upgrade the 'marked' package, version 0.3.5 is required for the a9 insecure components vulnerability"
   },
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
The `A9 - Insecure Components` example requires marked@0.3.5; that's the newest version affected by the XSS described in the tutorial. After A9 was implemented the package.json got updated to use marked@0.3.9, and that stopped the example exploit from working.

This changes the package.json to specify marked@0.3.5 so the tutorial example works as expected.

Fixes #199