### PR TITLE
Add test of A9 vulnerability

### DIFF
--- a/apps/server-render/test/e2e/integration/memos_spec.js
+++ b/apps/server-render/test/e2e/integration/memos_spec.js
@@ -48,4 +48,25 @@ describe('/memos behaviour', () => {
             .should('be.visible')
             .contains(text)
     })
+
+    it('Should demonstrate A9', () => {
+        const label = 'marked XSS'
+        const text = `[${label}](javascript&#58this;alert(1&#41;)`
+
+        cy.userSignIn()
+        cy.visitPage('/memos')
+        cy.get('textarea[name="memo"]')
+            .clear()
+            .type(text)
+
+        cy.get('button[type="submit"]')
+            .click()
+
+        cy.url().should('include', 'memos')
+
+        cy.get('.panel-body > p > a')
+            .contains(label)
+            .should('be.visible')
+            .should('have.attr', 'href', 'javascript:this;alert(1)')
+    })
 })


### PR DESCRIPTION
[As discussed in PR#206](https://github.com/OWASP/NodeGoat/pull/206#issuecomment-670193032), this PR adds a test which verifies the A9 vulnerability is present.

The test tries to create a memo with the content:
`[marked XSS](javascript&#58this;alert(1&#41;)`

...and verifies that the resulting memo contains a link with the expected label/href:
`marked XSS` / `javascript:this;alert(1)`

With marked 0.3.6 and later the markdown will be escaped, so the link will be missing from the resulting memo and the test will fail.