### PR TITLE
Use correct DB URI under docker-compose

### DIFF
--- a/apps/server-render/docker-compose.yml
+++ b/apps/server-render/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3.7"
 services:
   web:
     build: .
+    environment:
+      NODE_ENV:
+      MONGODB_URI: mongodb://mongo:27017/nodegoat
     command: sh -c "until nc -z -w 2 mongo 27017 && echo 'mongo is ready for connections' && node artifacts/db-reset.js && npm start; do sleep 2; done"
     ports:
       - "4000:4000"


### PR DESCRIPTION
**Note:** This PR is against `feature/187` rather than `master`. The issue exists in both branches, but it only causes CI failures in `feature/187`. I feel that makes it a "nice to have" in `master`, but high priority in this branch. 

Currently the three jobs in `feature/187` CI builds all connect to the same mongolab URI. Only one job in each build can succeed; the others will fail the signup spec because the "new user" already exists in the database.

This change updates the docker-compose configuration to set the `MONGODB_URI` env var. That makes the web service connect to the mongo service (in the other container) rather than the default mongolab URI.

It also propagates `NODE_ENV` from the environment where docker-compose is run into the web container. That means the web service uses the appropriate config instead of always using development.

This should make the CI builds in this branch as reliable those in `master`. There's still one other issue that needs fixing to make it fully reliable, see #159 for further details.