### PR TITLE
Fix intermittent test failures

### DIFF
--- a/artifacts/db-reset.js
+++ b/artifacts/db-reset.js
@@ -6,7 +6,6 @@
 // before running it (default: development). ie:
 // NODE_ENV=production node artifacts/db-reset.js
 
-const _ = require("underscore");
 const { MongoClient } = require("mongodb");
 const { db } = require("../config/config");
 
@@ -37,7 +36,16 @@ const USERS_TO_INSERT = [
         //"password" : "$2a$10$Tlx2cNv15M0Aia7wyItjsepeA8Y6PyBYaNdQqvpxkIUlcONf1ZHyq", // User2_123
     }];
 
-// Getting the global config taking in account he environment (proc)
+const tryDropCollection = (db, name) => {
+    return new Promise((resolve, reject) => {
+        db.dropCollection(name, (err, data) => {
+            if (!err) {
+                console.log(`Dropped collection: ${name}`);
+            }
+            resolve(undefined);
+        });
+    });
+}
 
 const parseResponse = (err, res, comm) => {
     if (err) {
@@ -58,60 +66,70 @@ MongoClient.connect(db, (err, db) =>  {
         console.log(JSON.stringify(err));
         process.exit(1);
     }
-    console.log("Connected to the database: " + db);
+    console.log("Connected to the database");
+
+    const collectionNames = [
+        "users",
+        "allocations",
+        "contributions",
+        "memos",
+        "counters"
+    ];
 
     // remove existing data (if any), we don't want to look for errors here
-    db.dropCollection("users");
-    db.dropCollection("allocations");
-    db.dropCollection("contributions");
-    db.dropCollection("memos");
-    db.dropCollection("counters");
+    console.log("Dropping existing collections");
+    const dropPromises = collectionNames.map((name) => tryDropCollection(db, name));
 
-    const usersCol = db.collection("users");
-    const allocationsCol = db.collection("allocations");
-    const countersCol = db.collection("counters");
+    // Wait for all drops to finish (or fail) before continuing
+    Promise.all(dropPromises).then(() => {
+        const usersCol = db.collection("users");
+        const allocationsCol = db.collection("allocations");
+        const countersCol = db.collection("counters");
 
-    // reset unique id counter
-    countersCol.insert({
-        _id: "userId",
-        seq: 3
-    });
+        // reset unique id counter
+        countersCol.insert({
+            _id: "userId",
+            seq: 3
+        }, (err, data) => {
+            parseResponse(err, data, "countersCol.insert");
+        });
 
-    // insert admin and test users
-    console.log("Users to insert:");
-    USERS_TO_INSERT.forEach((user) => console.log(JSON.stringify(user)));
+        // insert admin and test users
+        console.log("Users to insert:");
+        USERS_TO_INSERT.forEach((user) => console.log(JSON.stringify(user)));
 
-    usersCol.insertMany(USERS_TO_INSERT, (err, data) => {
-        const finalAllocations = [];
+        usersCol.insertMany(USERS_TO_INSERT, (err, data) => {
+            const finalAllocations = [];
 
-        // We can't continue if error here
-        if (err) {
-            console.log("ERROR: insertMany");
-            console.log(JSON.stringify(err));
-            process.exit(1);
-        }
-        parseResponse(err, data, "users.insertMany");
+            // We can't continue if error here
+            if (err) {
+                console.log("ERROR: insertMany");
+                console.log(JSON.stringify(err));
+                process.exit(1);
+            }
+            parseResponse(err, data, "users.insertMany");
 
-        data.ops.forEach((user) => {
-            const stocks = Math.floor((Math.random() * 40) + 1);
-            const funds = Math.floor((Math.random() * 40) + 1);
+            data.ops.forEach((user) => {
+                const stocks = Math.floor((Math.random() * 40) + 1);
+                const funds = Math.floor((Math.random() * 40) + 1);
 
-            finalAllocations.push({
-                userId: user._id,
-                stocks: stocks,
-                funds: funds,
-                bonds: 100 - (stocks + funds)
+                finalAllocations.push({
+                    userId: user._id,
+                    stocks: stocks,
+                    funds: funds,
+                    bonds: 100 - (stocks + funds)
+                });
             });
+
+            console.log("Allocations to insert:");
+            finalAllocations.forEach(allocation => console.log(JSON.stringify(allocation)));
+
+            allocationsCol.insertMany(finalAllocations, (err, data) => {
+                parseResponse(err, data, "allocations.insertMany");
+                console.log("Database reset performed successfully")
+                process.exit(0);
+            });
+
         });
-
-        console.log("Allocations to insert:");
-        finalAllocations.forEach(allocation => console.log(JSON.stringify(allocation)));
-
-        allocationsCol.insertMany(finalAllocations, (err, data) => {
-            parseResponse(err, data, "allocations.insertMany");
-            console.log("Database reset performed successfully")
-            process.exit(0);
-        });
-
     });
 });


### PR DESCRIPTION
Sometimes the cypress tests fail in CI when they should have passed. Rerunning the tests eventually gets them to go green, but that makes unnecessary work for the maintainers. The change in this PR fixes the main issue causing this problem in the master branch.

This issues affects all branches, but it's intermittent. The nodegoat service fails with:
```
TypeError: Cannot read property 'seq' of null
    at /home/travis/build/OWASP/NodeGoat/app/data/user-dao.js:119:83
```
All cypress tests fail after that point. For example: https://travis-ci.com/github/OWASP/NodeGoat/jobs/298947707

That happens because the db-reset script doesn't wait for the collection drop commands to complete before inserting new data. The command to insert the userId counter can run against the old collection, just before it gets deleted. The test then fails when nodegoat tries to add a user and can't get the userId counter.

21d5740 prevents that by waiting for all the collection drops to complete (or fail) before starting to insert new data. Sorry if the diff looks complex, the last ~50 lines is mainly just an extra level of indentation. It's much clearer with "hide whitespace changes" enabled.