### PR TITLE
Remove mongolab addon from Heroku deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,89 +9,116 @@ OWASP Top 10 for Node.js web applications:
 [Tutorial Guide](http://nodegoat.herokuapp.com/tutorial) explaining how each of the OWASP Top 10 vulnerabilities can manifest in Node.js web apps and how to prevent it.
 
 ### Do it!
-[A Vulnerable Node.js App for Ninjas](http://nodegoat.herokuapp.com/) to exploit, toast, and fix. You may like to [set up your own copy](#how-to-setup-your-copy-of-nodegoat) of the app to fix and test vulnerabilities. Hint: Look for comments in the source code.
+[A Vulnerable Node.js App for Ninjas](http://nodegoat.herokuapp.com/) to exploit, toast, and fix. You may like to [set up your own copy](#how-to-set-up-your-copy-of-nodegoat) of the app to fix and test vulnerabilities. Hint: Look for comments in the source code.
 ##### Default user accounts
 The database comes pre-populated with these user accounts created as part of the seed data -
 * Admin Account - u:admin p:Admin_123
 * User Accounts (u:user1 p:User1_123), (u:user2 p:User2_123)
 * New users can also be added using the sign-up page.
 
-## How to Setup Your Copy of NodeGoat
+## How to Set Up Your Copy of NodeGoat
 
-### OPTION 1 - One click install on Heroku
-The the quickest way to get running with NodeGoat is to click the button below to deploy it on Heroku.
+### OPTION 1 - Run NodeGoat on your machine
 
-Even though it is not essential, but recommended that you fork this repository and deploy the forked repo.
-This would allow you to fix vulnerabilities in your own forked version, and deploy and test it on heroku.
+1) Install [Node.js](http://nodejs.org/) - NodeGoat requires Node v8 or above
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+2) Clone the github repository:
+   ```
+   git clone https://github.com/OWASP/NodeGoat.git
+   ```
 
-This Heroku instance uses Free ($0/month) node server and MongoLab add-on.
+3) Go to the directory:
+   ```
+   cd NodeGoat
+   ```
 
-### OPTION 2 - Run NodeGoat on your machine
+4) Install node packages:
+   ```
+   npm install
+   ```
 
-If you do not wish to run NodeGoat on Heroku, please follow these steps to setup and run it locally -
-* Install [Node.js](http://nodejs.org/) - NodeGoat requires Node v8 or above
+5) Set up MongoDB. You can either install MongoDB locally or create a remote instance:
 
-* Clone the github repository
-```
-git clone https://github.com/OWASP/NodeGoat.git
-```
+   * Using local MongoDB:
+     1) Install [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/)
+     2) Start [mongod](http://docs.mongodb.org/manual/reference/program/mongod/#bin.mongod)
 
-*go to the directory
-```
-cd NodeGoat
-```
+   * Using remote MongoDB instance:
+     1) [Deploy a MongoDB Atlas free tier cluster](https://docs.atlas.mongodb.com/tutorial/deploy-free-tier-cluster/) (M0 Sandbox)
+     2) [Enable network access](https://docs.atlas.mongodb.com/security/add-ip-address-to-list/) to the cluster from your current IP address
+     3) [Add a database user](https://docs.atlas.mongodb.com/tutorial/create-mongodb-user-for-cluster/) to the cluster
+     4) Set the `MONGODB_URI` environment variable to the connection string of your cluster. Your connection string can be viewed in the cluster's [connect dialog](https://docs.atlas.mongodb.com/tutorial/connect-to-your-cluster/#connect-to-your-atlas-cluster), and will be in the form:
+        <br>`mongodb+srv://<username>:<password>@<cluster>/<dbname>?retryWrites=true&w=majority`
 
-* Install node modules
-```
-npm install
-```
+6) Populate MongoDB with the seed data required for the app:
+   ```
+   npm run db:seed
+   ```
+   By default this will use the "development" configuration, but the desired config can be passed as an argument if required.
 
-* Create Mongo DB:
-    You can create a remote MongoDB instance or use local mongod installation
-    * A. Using Remote MongoDB
-        * Create a sandbox mongoDB instance (free) at [mLab](https://mlab.com/plans/pricing/#plan-sandbox)
-        * Create a new database.
-        * Create a user.
-        * Update the `db` property in file `config/env/development.js` to reflect your DB setup. (in format: `mongodb://<username>:<password>@<databasename>`)
-    * OR B.Using local MongoDB
-        * If using local Mongo DB instance, start [mongod](http://docs.mongodb.org/manual/reference/program/mongod/#bin.mongod).
-        * Update the `db` property in file `config/env/development.js` to reflect your DB setup. (in format: `mongodb://localhost:27017/<databasename>`)
-
-* Populate MongoDB with seed data required for the app
-    * Run the npm-script below to populate the DB with seed data required for the application. Pass the desired environment as argument. If not passed, "development" is the default:
-```
-npm run db:seed
-```
-* Start server, this starts the NodeGoat application at url [http://localhost:4000/](http://localhost:4000/)
-```
-npm start
-```
-
-* Start server with nodemon, this starts the NodeGoat application at url [http://localhost:5000/](http://localhost:5000/)
-```
-npm run dev
-```
-
-### OPTION 3 - Run NodeGoat on Docker
-
-**You need to install [docker](https://docs.docker.com/installation/) and [docker compose](https://docs.docker.com/compose/install/) to be able to use this option**
-
-The repo includes the Dockerfile and docker-compose.yml necessary to setup the app and the db instance then connect them together.
-
-* Build the images:
-```
-docker-compose build
-```
-* Run the app:
-```
-docker-compose up
-```
-
+7) Start the server. You can run the server using node or nodemon:
+   * Start the server with node. This starts the NodeGoat application at [http://localhost:4000/](http://localhost:4000/):
+     ```
+     npm start
+     ```
+   * Start the server with nodemon, which will automatically restart the application when you make any changes. This starts the NodeGoat application at [http://localhost:5000/](http://localhost:5000/):
+     ```
+     npm run dev
+     ```
 
 #### Customizing the Default Application Configuration
-The default application settings (database url, http port, etc.) can be changed by updating the [config file] (https://github.com/OWASP/NodeGoat/blob/master/config/env/all.js).
+By default the application will be hosted on port 4000 and will connect to a MongoDB instance at localhost:27017. To change this set the environment variables `PORT` and `MONGODB_URI`.
+
+Other settings can be changed by updating the [config file](https://github.com/OWASP/NodeGoat/blob/master/config/env/all.js).
+
+
+### OPTION 2 - Run NodeGoat on Docker
+
+The repo includes the Dockerfile and docker-compose.yml necessary to set up the app and db instance, then connect them together.
+
+1) Install [docker](https://docs.docker.com/installation/) and [docker compose](https://docs.docker.com/compose/install/) 
+
+2) Clone the github repository:
+   ```
+   git clone https://github.com/OWASP/NodeGoat.git
+   ```
+
+3) Go to the directory:
+   ```
+   cd NodeGoat
+   ```
+
+4) Build the images:
+   ```
+   docker-compose build
+   ```
+
+5) Run the app, this starts the NodeGoat application at http://localhost:4000/:
+   ```
+   docker-compose up
+   ```
+
+
+### OPTION 3 - Deploy to Heroku
+
+This option uses a free ($0/month) Heroku node server.
+
+Though not essential, it is recommended that you fork this repository and deploy the forked repo.
+This will allow you to fix vulnerabilities in your own forked version, then deploy and test it on Heroku.
+
+1) Set up a publicly accessible MongoDB instance:
+   1) [Deploy a MongoDB Atlas free tier cluster](https://docs.atlas.mongodb.com/tutorial/deploy-free-tier-cluster/) (M0 Sandbox)
+   2) [Enable network access](https://docs.atlas.mongodb.com/security/ip-access-list/#add-ip-access-list-entries) to the cluster from anywhere (CIDR range 0.0.0.0/0)
+   3) [Add a database user](https://docs.atlas.mongodb.com/tutorial/create-mongodb-user-for-cluster/) to the cluster
+
+2) Deploy NodeGoat to Heroku by clicking the button below:
+
+   [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
+   In the Create New App dialog, set the `MONGODB_URI` config var to the connection string of your MongoDB Atlas cluster.
+   Your connection string can be viewed in the cluster's [connect dialog](https://docs.atlas.mongodb.com/tutorial/connect-to-your-cluster/#connect-to-your-atlas-cluster), and will be in the form:
+   <br>`mongodb+srv://<username>:<password>@<cluster>/<dbname>?retryWrites=true&w=majority`
+
 
 ## Report bugs, Feedback, Comments
 *  Open a new [issue](https://github.com/OWASP/NodeGoat/issues) or contact team by joining chat at [Slack](https://owasp.slack.com/messages/project-nodegoat/) or [![Join the chat at https://gitter.im/OWASP/NodeGoat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OWASP/NodeGoat?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/README.md
+++ b/README.md
@@ -47,8 +47,14 @@ The database comes pre-populated with these user accounts created as part of the
      1) [Deploy a MongoDB Atlas free tier cluster](https://docs.atlas.mongodb.com/tutorial/deploy-free-tier-cluster/) (M0 Sandbox)
      2) [Enable network access](https://docs.atlas.mongodb.com/security/add-ip-address-to-list/) to the cluster from your current IP address
      3) [Add a database user](https://docs.atlas.mongodb.com/tutorial/create-mongodb-user-for-cluster/) to the cluster
-     4) Set the `MONGODB_URI` environment variable to the connection string of your cluster. Your connection string can be viewed in the cluster's [connect dialog](https://docs.atlas.mongodb.com/tutorial/connect-to-your-cluster/#connect-to-your-atlas-cluster), and will be in the form:
-        <br>`mongodb+srv://<username>:<password>@<cluster>/<dbname>?retryWrites=true&w=majority`
+     4) Set the `MONGODB_URI` environment variable to the connection string of your cluster, which can be viewed in the cluster's
+        [connect dialog](https://docs.atlas.mongodb.com/tutorial/connect-to-your-cluster/#connect-to-your-atlas-cluster). Select "Connect your application",
+        set the driver to "Node.js" and the version to "2.2.12 or later". This will give a connection string in the form:
+        ```
+        mongodb://<username>:<password>@<cluster>/<dbname>?ssl=true&replicaSet=<rsname>&authSource=admin&retryWrites=true&w=majority
+        ```
+        The `<username>` and `<password>` fields need filling in with the details of the database user added earlier. The `<dbname>` field sets the name of the
+        database nodegoat will use in the cluster (eg "nodegoat"). The other fields will already be filled in with the correct details for your cluster.
 
 6) Populate MongoDB with the seed data required for the app:
    ```
@@ -116,8 +122,14 @@ This will allow you to fix vulnerabilities in your own forked version, then depl
    [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
    In the Create New App dialog, set the `MONGODB_URI` config var to the connection string of your MongoDB Atlas cluster.
-   Your connection string can be viewed in the cluster's [connect dialog](https://docs.atlas.mongodb.com/tutorial/connect-to-your-cluster/#connect-to-your-atlas-cluster), and will be in the form:
-   <br>`mongodb+srv://<username>:<password>@<cluster>/<dbname>?retryWrites=true&w=majority`
+   This can be viewed in the cluster's [connect dialog](https://docs.atlas.mongodb.com/tutorial/connect-to-your-cluster/#connect-to-your-atlas-cluster).
+   Select "Connect your application", set the driver to "Node.js" and the version to "2.2.12 or later".
+   This will give a connection string in the form:
+   ```
+   mongodb://<username>:<password>@<cluster>/<dbname>?ssl=true&replicaSet=<rsname>&authSource=admin&retryWrites=true&w=majority
+   ```
+   The `<username>` and `<password>` fields need filling in with the details of the database user added earlier. The `<dbname>` field sets the name of the
+   database nodegoat will use in the cluster (eg "nodegoat"). The other fields will already be filled in with the correct details for your cluster.
 
 
 ## Report bugs, Feedback, Comments

--- a/README.md
+++ b/README.md
@@ -80,10 +80,6 @@ npm run dev
 
 The repo includes the Dockerfile and docker-compose.yml necessary to setup the app and the db instance then connect them together.
 
-* Change the db config in `config/env/development.js` to point to the respective Docker container.
-```
-db: "mongodb://mongo:27017/nodegoat",
-```
 * Build the images:
 ```
 docker-compose build

--- a/app.json
+++ b/app.json
@@ -13,6 +13,10 @@
     "postdeploy": "node artifacts/db-reset.js"
   },
   "env": {
+    "MONGODB_URI": {
+      "description": "Connection string for MongoDB database to use. Must be publicly accessible.",
+      "value": ""
+    },
     "NODE_ENV": {
       "description": "NODE_ENV for build and runtime. Must be in lowercase for Heroku build process.",
       "value": "production"
@@ -21,8 +25,5 @@
        "description": "Controls devDependency install: \"production\" = skip, \"all\" = install",
        "value": "production"
     }
-  },
-  "addons": [
-    "mongolab:sandbox"
-  ]
+  }
 }

--- a/app.json
+++ b/app.json
@@ -14,7 +14,12 @@
   },
   "env": {
     "NODE_ENV": {
-      "value": "PRODUCTION"
+      "description": "NODE_ENV for build and runtime. Must be in lowercase for Heroku build process.",
+      "value": "production"
+    },
+    "NPM_CONFIG_ONLY": {
+       "description": "Controls devDependency install: \"production\" = skip, \"all\" = install",
+       "value": "production"
     }
   },
   "addons": [

--- a/app/views/tutorial/a1.html
+++ b/app/views/tutorial/a1.html
@@ -237,10 +237,8 @@
                             <code>true</code>.</p>
                         <p>The same results can be achieved using other comparison operator such as
                             <code>$ne</code>.</p>
-                        <p>The demo application is vulnerable to the NoSQL Injection. For example, on the Allocations page, running a search with a malicious input `1'; return 1 == '1` retrieves allocations for all the users in the database.</p>
                     </div>
                 </div>
-
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <h3 class="panel-title">SSJS Attack Mechanics</h3>
@@ -268,26 +266,8 @@
                             <code>stocks</code> field as specified by
                             <code>threshold</code>. The problem is that these parameters are not validated, filtered, or sanitised, and vulnerable to SSJS Injection.
                         </p>
-
-
-                        <br/>
-                        <h5>NoSQL SSJS Injection</h5>
-                        <p>
-                            An attacker can send the following input for the
-                            <code>threshold</code> field in the requests query, which will create a valid JavaScript expression and satisfy the
-                            <code> $where</code> query as well, resulting in a DoS attack on the MongoDB server:
-                        </p>
-
-                        <pre>http://localhost:4000/allocations/2?threshold=5';while(true){};' </pre>
-                        <p>
-                            You can also just drop the following into the Stocks Threshold input box:
-                        </p>
-                        <pre>';while(true){};'</pre>
-
                     </div>
                 </div>
-
-
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <h3 class="panel-title">How Do I Prevent It?</h3>
@@ -299,9 +279,29 @@
                             <li>Input Validation: Validate inputs to detect malicious values. For NoSQL databases, also validate input types against expected types</li>
                             <li>Least Privilege: To minimize the potential damage of a successful injection attack, do not assign DBA or admin type access rights to your application accounts. Similarly minimize the privileges of the operating system account that the database process runs under.</li>
                         </ul>
-                        For the above NoSQL vulnerability, bare minimum fixes can be found in
+                    </div>
+                </div>
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Source Code Example</h3>
+                    </div>
+                    <div class="panel-body">
+                        <p><strong>Note: These vulnerabilities are not present when using an Atlas M0 cluster with NodeGoat.</strong></p>
+                        <p>The Allocations page of the demo application is vulnerable to NoSQL Injection. For example, set the stocks threshold filter to:</p>
+                        <pre>1'; return 1 == '1</pre>
+                        <p>This will retrieve allocations for all the users in the database.</p>
+                        <p>An attacker could also send the following input for the
+                            <code>threshold</code> field in the request's query, which will create a valid JavaScript expression and satisfy the
+                            <code> $where</code> query as well, resulting in a DoS attack on the MongoDB server:
+                        </p>
+                        <pre>http://localhost:4000/allocations/2?threshold=5';while(true){};' </pre>
+                        <p>
+                            You can also just drop the following into the Stocks Threshold input box:
+                        </p>
+                        <pre>';while(true){};'</pre>
+                        <p>For these vulnerabilities, bare minimum fixes can be found in
                         <code>allocations.html</code> and
-                        <code>allocations-dao.js</code>
+                        <code>allocations-dao.js</code></p>
                     </div>
                 </div>
             </div>
@@ -313,12 +313,12 @@
     <div class="panel panel-info">
         <div class="panel-heading">
             <h4 class="panel-title">
-                <a data-toggle="collapse" data-parent="#accordion" href="#collapseTwo">
+                <a data-toggle="collapse" data-parent="#accordion" href="#collapseThree">
                     <i class="fa fa-chevron-down"></i> A1 - 3 Log Injection
                 </a>
             </h4>
         </div>
-        <div id="collapseTwo" class="panel-collapse">
+        <div id="collapseThree" class="panel-collapse">
             <div class="panel-body">
 
 
@@ -360,7 +360,8 @@ Error: alex moldovan failed $1,000,000 transaction
                         <p>
                             An attacker may craft malicious input in hope of an escalated attack where the target isn't the logs themselves, but rather the actual logging system. For example, if an application has a back-office web app that manages viewing and tracking the logs, then an attacker may send an XSS payload into the log, which may not result in log forging on the log itself, but when viewed by a system administrator on the log viewing web app then it may compromise it and result in XSS injection that if the logs app is vulnerable.
                         </p>
-
+                    </div>
+                </div>
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <h3 class="panel-title">How Do I Prevent It?</h3>
@@ -387,9 +388,15 @@ console.log('Error: attempt to login with invalid user: %s', ESAPI.encoder().enc
 console.log('Error: attempt to login with invalid user: %s', ESAPI.encoder().encodeForJavaScript(userName));
 console.log('Error: attempt to login with invalid user: %s', ESAPI.encoder().encodeForURL(userName));
                         </pre>
-
-                        For the above Log Injection vulnerability, example and fix can be found at
-                        <code>routes/session.js</code>
+                    </div>
+                </div>
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Source Code Example</h3>
+                    </div>
+                    <div class="panel-body">
+                        <p>For the above Log Injection vulnerability, example and fix can be found at
+                        <code>routes/session.js</code></p>
                     </div>
                 </div>
             </div>

--- a/artifacts/db-reset.js
+++ b/artifacts/db-reset.js
@@ -6,7 +6,6 @@
 // before running it (default: development). ie:
 // NODE_ENV=production node artifacts/db-reset.js
 
-const _ = require("underscore");
 const { MongoClient } = require("mongodb");
 const { db } = require("../config/config");
 
@@ -37,7 +36,16 @@ const USERS_TO_INSERT = [
         //"password" : "$2a$10$Tlx2cNv15M0Aia7wyItjsepeA8Y6PyBYaNdQqvpxkIUlcONf1ZHyq", // User2_123
     }];
 
-// Getting the global config taking in account he environment (proc)
+const tryDropCollection = (db, name) => {
+    return new Promise((resolve, reject) => {
+        db.dropCollection(name, (err, data) => {
+            if (!err) {
+                console.log(`Dropped collection: ${name}`);
+            }
+            resolve(undefined);
+        });
+    });
+}
 
 const parseResponse = (err, res, comm) => {
     if (err) {
@@ -58,60 +66,70 @@ MongoClient.connect(db, (err, db) =>  {
         console.log(JSON.stringify(err));
         process.exit(1);
     }
-    console.log("Connected to the database: " + db);
+    console.log("Connected to the database");
+
+    const collectionNames = [
+        "users",
+        "allocations",
+        "contributions",
+        "memos",
+        "counters"
+    ];
 
     // remove existing data (if any), we don't want to look for errors here
-    db.dropCollection("users");
-    db.dropCollection("allocations");
-    db.dropCollection("contributions");
-    db.dropCollection("memos");
-    db.dropCollection("counters");
+    console.log("Dropping existing collections");
+    const dropPromises = collectionNames.map((name) => tryDropCollection(db, name));
 
-    const usersCol = db.collection("users");
-    const allocationsCol = db.collection("allocations");
-    const countersCol = db.collection("counters");
+    // Wait for all drops to finish (or fail) before continuing
+    Promise.all(dropPromises).then(() => {
+        const usersCol = db.collection("users");
+        const allocationsCol = db.collection("allocations");
+        const countersCol = db.collection("counters");
 
-    // reset unique id counter
-    countersCol.insert({
-        _id: "userId",
-        seq: 3
-    });
+        // reset unique id counter
+        countersCol.insert({
+            _id: "userId",
+            seq: 3
+        }, (err, data) => {
+            parseResponse(err, data, "countersCol.insert");
+        });
 
-    // insert admin and test users
-    console.log("Users to insert:");
-    USERS_TO_INSERT.forEach((user) => console.log(JSON.stringify(user)));
+        // insert admin and test users
+        console.log("Users to insert:");
+        USERS_TO_INSERT.forEach((user) => console.log(JSON.stringify(user)));
 
-    usersCol.insertMany(USERS_TO_INSERT, (err, data) => {
-        const finalAllocations = [];
+        usersCol.insertMany(USERS_TO_INSERT, (err, data) => {
+            const finalAllocations = [];
 
-        // We can't continue if error here
-        if (err) {
-            console.log("ERROR: insertMany");
-            console.log(JSON.stringify(err));
-            process.exit(1);
-        }
-        parseResponse(err, data, "users.insertMany");
+            // We can't continue if error here
+            if (err) {
+                console.log("ERROR: insertMany");
+                console.log(JSON.stringify(err));
+                process.exit(1);
+            }
+            parseResponse(err, data, "users.insertMany");
 
-        data.ops.forEach((user) => {
-            const stocks = Math.floor((Math.random() * 40) + 1);
-            const funds = Math.floor((Math.random() * 40) + 1);
+            data.ops.forEach((user) => {
+                const stocks = Math.floor((Math.random() * 40) + 1);
+                const funds = Math.floor((Math.random() * 40) + 1);
 
-            finalAllocations.push({
-                userId: user._id,
-                stocks: stocks,
-                funds: funds,
-                bonds: 100 - (stocks + funds)
+                finalAllocations.push({
+                    userId: user._id,
+                    stocks: stocks,
+                    funds: funds,
+                    bonds: 100 - (stocks + funds)
+                });
             });
+
+            console.log("Allocations to insert:");
+            finalAllocations.forEach(allocation => console.log(JSON.stringify(allocation)));
+
+            allocationsCol.insertMany(finalAllocations, (err, data) => {
+                parseResponse(err, data, "allocations.insertMany");
+                console.log("Database reset performed successfully")
+                process.exit(0);
+            });
+
         });
-
-        console.log("Allocations to insert:");
-        finalAllocations.forEach(allocation => console.log(JSON.stringify(allocation)));
-
-        allocationsCol.insertMany(finalAllocations, (err, data) => {
-            parseResponse(err, data, "allocations.insertMany");
-            console.log("Database reset performed successfully")
-            process.exit(0);
-        });
-
     });
 });

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -1,11 +1,7 @@
 // default app configuration
 
 const port = process.env.PORT || 4000;
-let db = process.env.MONGOLAB_URI || process.env.MONGODB_URI;
-
-if (!db) {
-  db = process.env.NODE_ENV === 'test' ? "mongodb://localhost:27017/nodegoat" : "mongodb://nodegoat:owasp@ds159217.mlab.com:59217/nodegoat";
-}
+let db = process.env.MONGODB_URI || "mongodb://localhost:27017/nodegoat";
 
 module.exports = {
     port,

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -1,16 +1,4 @@
 module.exports = {
-   // Local instance.
-   // To install mongodb: https://docs.mongodb.org/manual/tutorial/
-   // With mongodb installed, All you should need to do is uncomment the `db` property below, and run the following command:
-   // grunt db-reset:development
-   // That will create the local nodegoat data-store, or restore it to a clean state if it already exists.
-
-   // db: "mongodb://localhost:27017/nodegoat",
-
-   // If you want to use a MongoLab instance, just sign up for it, create a data-store, in this example we call it nodegoat.
-   // and again just run the grunt db-reset:development command
-   //db: 'mongodb://<dbuser>:<dbpassword>@<databasename>',
-
    // If you want to debug regression tests, you will need the following which is also in the test config:
    zapHostName: "192.168.56.20",
    zapPort: "8080",

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+    "blacklistHosts": "*:35729",
     "fixturesFolder": "test/e2e/fixtures",
     "integrationFolder": "test/e2e/integration",
     "pluginsFile": "test/e2e/plugins/index.js",
@@ -6,4 +7,4 @@
     "videosFolder": "test/e2e/videos",
     "supportFile": "test/e2e/support/index.js",
     "video": false
-  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3.7"
 services:
   web:
     build: .
+    environment:
+      NODE_ENV:
+      MONGODB_URI: mongodb://mongo:27017/nodegoat
     command: sh -c "until nc -z -w 2 mongo 27017 && echo 'mongo is ready for connections' && node artifacts/db-reset.js && npm start; do sleep 2; done"
     ports:
       - "4000:4000"


### PR DESCRIPTION
As raised in #212, mLab is shutting down their mongolab Heroku addon on November 10th 2020.  This is a WIP pull request containing the changes to remove the addon and update documentation.

The functional changes are complete and the next step is the documentation. I'm posting this draft so contributors can comment on the general approach and give feedback on the documentation changes once they are added.

This branch cannot be merged until after PR #214, and it also requires the docker-compose fix from my [fix/mongodb-uri](https://github.com/rcowsill/NodeGoat/tree/fix/mongodb-uri) branch. It also includes a change to speed up Cypress tests, which can be pulled out if required.

Tasks:
- [x] Remove mongolab:sandbox addon from app.json
- [x] Add a MONGODB_URI env variable to app.json (required, default `""`)
- [x] Remove reference to the current mLab database from config/env/all.js
- [x] Remove support for MONGOLAB_URI in config/env/all.js (only needed for the mongolab addon)
- [x] Update heroku deploy instructions in README.md to cover database setup
- [x] Update tutorial for `A1 - Injection` to say NoSQL injection is blocked on deployments using Atlas M0