### PR TITLE
Adjustments to livereload to stop (timeout) in prod

### DIFF
--- a/app/routes/allocations.js
+++ b/app/routes/allocations.js
@@ -1,6 +1,9 @@
 const AllocationsDAO = require("../data/allocations-dao").AllocationsDAO;
+const {
+    environmentalScripts
+} = require("../../config/config");
 
-function AllocationsHandler (db) {
+function AllocationsHandler(db) {
     "use strict";
 
     const allocationsDAO = new AllocationsDAO(db);
@@ -10,12 +13,20 @@ function AllocationsHandler (db) {
         // Fix for A4 Insecure DOR -  take user id from session instead of from URL param
         const { userId } = req.session;
         */
-        const {userId} = req.params;
-        const { threshold } = req.query
+        const {
+            userId
+        } = req.params;
+        const {
+            threshold
+        } = req.query
 
         allocationsDAO.getByUserIdAndThreshold(userId, threshold, (err, allocations) => {
             if (err) return next(err);
-            return res.render("allocations", { userId, allocations });
+            return res.render("allocations", {
+                userId,
+                allocations,
+                environmentalScripts
+            });
         });
     };
 }

--- a/app/routes/benefits.js
+++ b/app/routes/benefits.js
@@ -1,6 +1,11 @@
-const { BenefitsDAO } = require("../data/benefits-dao");
+const {
+    BenefitsDAO
+} = require("../data/benefits-dao");
+const {
+    environmentalScripts
+} = require("../../config/config");
 
-function BenefitsHandler (db) {
+function BenefitsHandler(db) {
     "use strict";
 
     const benefitsDAO = new BenefitsDAO(db);
@@ -15,13 +20,17 @@ function BenefitsHandler (db) {
                 users,
                 user: {
                     isAdmin: true
-                }
+                },
+                environmentalScripts
             });
         });
     };
 
     this.updateBenefits = (req, res, next) => {
-        const { userId, benefitStartDate } = req.body;
+        const {
+            userId,
+            benefitStartDate
+        } = req.body;
 
         benefitsDAO.updateBenefits(userId, benefitStartDate, (error) => {
 
@@ -35,7 +44,8 @@ function BenefitsHandler (db) {
                     user: {
                         isAdmin: true
                     },
-                    updateSuccess: true
+                    updateSuccess: true,
+                    environmentalScripts
                 };
 
                 return res.render("benefits", data);

--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -1,19 +1,27 @@
 const ContributionsDAO = require("../data/contributions-dao").ContributionsDAO;
+const {
+    environmentalScripts
+} = require("../../config/config");
 
 /* The ContributionsHandler must be constructed with a connected db */
-function ContributionsHandler (db) {
+function ContributionsHandler(db) {
     "use strict";
 
     const contributionsDAO = new ContributionsDAO(db);
 
     this.displayContributions = (req, res, next) => {
-        const { userId } = req.session;
+        const {
+            userId
+        } = req.session;
 
         contributionsDAO.getByUserId(userId, (error, contrib) => {
             if (error) return next(error);
 
             contrib.userId = userId; //set for nav menu items
-            return res.render("contributions", contrib);
+            return res.render("contributions", {
+                ...contrib,
+                environmentalScripts
+            });
         });
     };
 
@@ -31,7 +39,9 @@ function ContributionsHandler (db) {
         const afterTax = parseInt(req.body.afterTax);
         const roth = parseInt(req.body.roth);
         */
-        const { userId } = req.session;
+        const {
+            userId
+        } = req.session;
 
         //validate contributions
         const validations = [isNaN(preTax), isNaN(afterTax), isNaN(roth), preTax < 0, afterTax < 0, roth < 0]
@@ -39,14 +49,16 @@ function ContributionsHandler (db) {
         if (isInvalid) {
             return res.render("contributions", {
                 updateError: "Invalid contribution percentages",
-                userId
+                userId,
+                environmentalScripts
             });
         }
         // Prevent more than 30% contributions
         if (preTax + afterTax + roth > 30) {
             return res.render("contributions", {
                 updateError: "Contribution percentages cannot exceed 30 %",
-                userId
+                userId,
+                environmentalScripts
             });
         }
 
@@ -55,7 +67,10 @@ function ContributionsHandler (db) {
             if (err) return next(err);
 
             contributions.updateSuccess = true;
-            return res.render("contributions", contributions);
+            return res.render("contributions", {
+                ...contributions,
+                environmentalScripts
+            });
         });
 
     };

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,7 +5,9 @@ const ContributionsHandler = require("./contributions");
 const AllocationsHandler = require("./allocations");
 const MemosHandler = require("./memos");
 const ResearchHandler = require("./research");
-
+const {
+    environmentalScripts
+} = require("../../config/config");
 const ErrorHandler = require("./error").errorHandler;
 
 const index = (app, db) => {
@@ -74,12 +76,18 @@ const index = (app, db) => {
 
     // Handle redirect for learning resources link
     app.get("/tutorial", (req, res) => {
-        return res.render("tutorial/a1");
+        return res.render("tutorial/a1", {
+            environmentalScripts
+        });
     });
-    
+
     app.get("/tutorial/:page", (req, res) => {
-        const { page } = req.params
-        return res.render(`tutorial/${page}`);
+        const {
+            page
+        } = req.params
+        return res.render(`tutorial/${page}`, {
+            environmentalScripts
+        });
     });
 
     // Research Page

--- a/app/routes/memos.js
+++ b/app/routes/memos.js
@@ -1,6 +1,9 @@
 const MemosDAO = require("../data/memos-dao").MemosDAO;
+const {
+    environmentalScripts
+} = require("../../config/config");
 
-function MemosHandler (db) {
+function MemosHandler(db) {
     "use strict";
 
     const memosDAO = new MemosDAO(db);
@@ -15,13 +18,16 @@ function MemosHandler (db) {
 
     this.displayMemos = (req, res, next) => {
 
-        const { userId } = req.session;
+        const {
+            userId
+        } = req.session;
 
         memosDAO.getAllMemos((err, docs) => {
             if (err) return next(err);
             return res.render("memos", {
                 memosList: docs,
-                userId: userId
+                userId: userId,
+                environmentalScripts
             });
         });
     };

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,14 +1,19 @@
 const ProfileDAO = require("../data/profile-dao").ProfileDAO;
 const ESAPI = require('node-esapi')
+const {
+    environmentalScripts
+} = require("../../config/config");
 
 /* The ProfileHandler must be constructed with a connected db */
-function ProfileHandler (db) {
+function ProfileHandler(db) {
     "use strict";
 
     const profile = new ProfileDAO(db);
 
     this.displayProfile = (req, res, next) => {
-        const { userId } = req.session;
+        const {
+            userId
+        } = req.session;
 
 
 
@@ -25,13 +30,24 @@ function ProfileHandler (db) {
             // the context of a URL in a link header
             // doc.website = ESAPI.encoder().encodeForURL(doc.website)
 
-            return res.render("profile", doc);
+            return res.render("profile", {
+                ...doc,
+                environmentalScripts
+            });
         });
     };
 
     this.handleProfileUpdate = (req, res, next) => {
 
-        const {firstName, lastName, ssn, dob, address, bankAcc, bankRouting} = req.body;
+        const {
+            firstName,
+            lastName,
+            ssn,
+            dob,
+            address,
+            bankAcc,
+            bankRouting
+        } = req.body;
 
         // Fix for Section: ReDoS attack
         // The following regexPattern that is used to validate the bankRouting number is insecure and vulnerable to
@@ -54,11 +70,14 @@ function ProfileHandler (db) {
                 dob,
                 address,
                 bankAcc,
-                bankRouting
+                bankRouting,
+                environmentalScripts
             });
         }
 
-        const { userId } = req.session;
+        const {
+            userId
+        } = req.session;
 
         profile.updateUser(
             parseInt(userId),
@@ -78,7 +97,10 @@ function ProfileHandler (db) {
                 user.updateSuccess = true;
                 user.userId = userId;
 
-                return res.render("profile", user);
+                return res.render("profile", {
+                    ...user,
+                    environmentalScripts
+                });
             }
         );
 

--- a/app/routes/research.js
+++ b/app/routes/research.js
@@ -1,26 +1,33 @@
 const ResearchDAO = require("../data/research-dao").ResearchDAO;
 const needle = require('needle');
+const {
+    environmentalScripts
+} = require("../../config/config");
 
-function ResearchHandler (db) {
+function ResearchHandler(db) {
     "use strict";
 
     const researchDAO = new ResearchDAO(db);
 
     this.displayResearch = (req, res) => {
-        
+
         if (req.query.symbol) {
-            const url = req.query.url+req.query.symbol; 
+            const url = req.query.url + req.query.symbol;
             return needle.get(url, (error, newResponse) => {
                 if (!error && newResponse.statusCode == 200)
-                    res.writeHead(200, {'Content-Type': 'text/html'});
-                    res.write('<h1>The following is the stock information you requested.</h1>\n\n');
-                    res.write('\n\n');
-                    res.write(newResponse.body);
-                    return res.end();
+                    res.writeHead(200, {
+                        'Content-Type': 'text/html'
+                    });
+                res.write('<h1>The following is the stock information you requested.</h1>\n\n');
+                res.write('\n\n');
+                res.write(newResponse.body);
+                return res.end();
             });
         }
-        
-        return res.render("research");
+
+        return res.render("research", {
+            environmentalScripts
+        });
     };
 
 }

--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -1,8 +1,11 @@
 const UserDAO = require("../data/user-dao").UserDAO;
 const AllocationsDAO = require("../data/allocations-dao").AllocationsDAO;
+const {
+    environmentalScripts
+} = require("../../config/config");
 
 /* The SessionHandler must be constructed with a connected db */
-function SessionHandler (db) {
+function SessionHandler(db) {
     "use strict";
 
     const userDAO = new UserDAO(db);
@@ -22,16 +25,16 @@ function SessionHandler (db) {
     this.isAdminUserMiddleware = (req, res, next) => {
         if (req.session.userId) {
             return userDAO.getUserById(req.session.userId, (err, user) => user && user.isAdmin ? next() : res.redirect("/login"));
-        } 
+        }
         console.log("redirecting to login");
         return res.redirect("/login");
-        
+
     };
 
     this.isLoggedInMiddleware = (req, res, next) => {
         if (req.session.userId) {
             return next();
-        } 
+        }
         console.log("redirecting to login");
         return res.redirect("/login");
     };
@@ -40,12 +43,16 @@ function SessionHandler (db) {
         return res.render("login", {
             userName: "",
             password: "",
-            loginError: ""
+            loginError: "",
+            environmentalScripts
         });
     };
 
     this.handleLoginRequest = (req, res, next) => {
-        const { userName, password }  = req.body
+        const {
+            userName,
+            password
+        } = req.body
         userDAO.validateLogin(userName, password, (err, user) => {
             const errorMessage = "Invalid username and/or password";
             const invalidUserNameErrorMessage = "Invalid username";
@@ -69,18 +76,19 @@ function SessionHandler (db) {
                     return res.render("login", {
                         userName: userName,
                         password: "",
-                        loginError: invalidUserNameErrorMessage
+                        loginError: invalidUserNameErrorMessage,
                         //Fix for A2-2 Broken Auth - Uses identical error for both username, password error
                         // loginError: errorMessage
+                        environmentalScripts
                     });
                 } else if (err.invalidPassword) {
                     return res.render("login", {
                         userName: userName,
                         password: "",
-                        loginError: invalidPasswordErrorMessage
+                        loginError: invalidPasswordErrorMessage,
                         //Fix for A2-2 Broken Auth - Uses identical error for both username, password error
                         // loginError: errorMessage
-
+                        environmentalScripts
                     });
                 } else {
                     return next(err);
@@ -116,7 +124,8 @@ function SessionHandler (db) {
             email: "",
             userNameError: "",
             emailError: "",
-            verifyError: ""
+            verifyError: "",
+            environmentalScripts
         });
     };
 
@@ -173,7 +182,14 @@ function SessionHandler (db) {
 
     this.handleSignup = (req, res, next) => {
 
-        const { email, userName, firstName, lastName, password, verify } = req.body;
+        const {
+            email,
+            userName,
+            firstName,
+            lastName,
+            password,
+            verify
+        } = req.body;
 
         // set these up in case we have an error case
         const errors = {
@@ -189,7 +205,10 @@ function SessionHandler (db) {
 
                 if (user) {
                     errors.userNameError = "User name already in use. Please choose another";
-                    return res.render("signup", errors);
+                    return res.render("signup", {
+                        ...errors,
+                        environmentalScripts
+                    });
                 }
 
                 userDAO.addUser(userName, firstName, lastName, password, email, (err, user) => {
@@ -203,7 +222,7 @@ function SessionHandler (db) {
                         if (err) return next(err);
                         res.cookie("session", sessionId);
                         req.session.userId = user._id;
-                        return res.render("dashboard", user);
+                        return res.render("dashboard", { ...user, environmentalScripts });
                     });
                     */
                     req.session.regenerate(() => {
@@ -211,14 +230,20 @@ function SessionHandler (db) {
                         // Set userId property. Required for left nav menu links
                         user.userId = user._id;
 
-                        return res.render("dashboard", user);
+                        return res.render("dashboard", {
+                            ...user,
+                            environmentalScripts
+                        });
                     });
 
                 });
             });
         } else {
             console.log("user did not validate");
-            return res.render("signup", errors);
+            return res.render("signup", {
+                ...errors,
+                environmentalScripts
+            });
         }
     };
 
@@ -235,7 +260,10 @@ function SessionHandler (db) {
         userDAO.getUserById(userId, (err, doc) => {
             if (err) return next(err);
             doc.userId = userId;
-            return res.render("dashboard", doc);
+            return res.render("dashboard", {
+                ...doc,
+                environmentalScripts
+            });
         });
     };
 }

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -121,10 +121,10 @@
     <!-- tour steps related js -->
     <script src="/js/tour/redirects-steps.js"></script>
 
-    <!-- Load live reload script -->
-    <script>
-    document.write("<script src='//" + (location.host || "localhost").split(":")[0] + ":35729/livereload.js'></" + "script>");
-    </script>
+    <!-- Load environmental scripts such as live reload -->
+    {% for script in environmentalScripts %}
+    {{script}}
+    {% endfor %}
 
 </body>
 

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -87,10 +87,10 @@
                             <span style="font-size: x-large">
                                 <span class="fa fa-bullseye"></span>Retire<b>Easy</b>
                             </span>
-                            <br/>
+                            <br />
                             <span style="font-size: medium">Employee Retirement Savings Management</span>
-                            <br/>
-                            <br/>
+                            <br />
+                            <br />
                         </div>
                         <div class="panel-body">
 
@@ -141,10 +141,11 @@
     <!-- Bootstrap core JavaScript -->
     <script src="/vendor/jquery.min.js"></script>
     <script src="/vendor/bootstrap/bootstrap.js"></script>
-    <!-- Load live reload script -->
+    <!-- Load environmental scripts such as live reload -->
+    {% for script in environmentalScripts %}
+    {{script}}
+    {% endfor %}
     <script type="application/javascript">
-    document.write("<script src='http://" + (location.host || "localhost").split(":")[0] + ":35729/livereload.js'></" + "script>");
-
     const areCookiesEnabled = () => {
         const cookieEnabled = navigator.cookieEnabled;
 
@@ -158,9 +159,9 @@
             document.cookie = "testcookie=1";
 
             if (!document.cookie) return false;
-           
+
             document.cookie = "testcookie=; expires=" + new Date(0).toUTCString();
-            
+
         }
 
         return true;

--- a/app/views/signup.html
+++ b/app/views/signup.html
@@ -121,10 +121,10 @@
     <!-- Bootstrap core JavaScript -->
     <script src="/vendor/jquery.min.js"></script>
     <script src="/vendor/bootstrap/bootstrap.js"></script>
-    <!-- Load live reload script -->
-    <script>
-    document.write("<script src='http://" + (location.host || "localhost").split(":")[0] + ":35729/livereload.js'></" + "script>");
-    </script>
+    <!-- Load environmental scripts such as live reload -->
+    {% for script in environmentalScripts %}
+    {{script}}
+    {% endfor %}
 
 </body>
 

--- a/app/views/tutorial/layout.html
+++ b/app/views/tutorial/layout.html
@@ -91,10 +91,10 @@
 
     <script src="../vendor/jquery.min.js"></script>
     <script src="../vendor/bootstrap/bootstrap.js"></script>
-    <!-- Load live reload script -->
-    <script>
-    document.write("<script src='http://" + (location.host || "localhost").split(":")[0] + ":35729/livereload.js'></" + "script>");
-    </script>
+    <!-- Load environmental scripts such as live reload -->
+    {% for script in environmentalScripts %}
+    {{script}}
+    {% endfor %}
 
 </body>
 

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -14,5 +14,6 @@ module.exports = {
     cryptoKey: "a_secure_key_for_crypto_here",
     cryptoAlgo: "aes256",
     hostName: "localhost",
-    environmentalScripts: ["<script src='//localhost:35729/livereload.js'></script>"]
+    environmentalScripts: []
 };
+

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -13,5 +13,6 @@ module.exports = {
     cookieSecret: "session_cookie_secret_key_here",
     cryptoKey: "a_secure_key_for_crypto_here",
     cryptoAlgo: "aes256",
-    hostName: "localhost"
+    hostName: "localhost",
+    environmentalScripts: ["<script src='//localhost:35729/livereload.js'></script>"]
 };

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -17,5 +17,6 @@ module.exports = {
    // Required from Zap 2.4.1. This key is set in Zap Options -> API _Api Key.
    zapApiKey: "v9dn0balpqas1pcc281tn5ood1",
    // Required if debugging security regression tests.
-   zapApiFeedbackSpeed: 5000 // Milliseconds.
+   zapApiFeedbackSpeed: 5000, // Milliseconds.
+   environmentalScripts: [`<script>document.write("<script src='http://" + (location.host || "localhost").split(":")[0] + ":35729/livereload.js'></" + "script>");</script>`]
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,3 +1,1 @@
-module.exports = {
-   environmentalScripts: []
-};
+module.exports = {};

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,1 +1,3 @@
-module.exports = {};
+module.exports = {
+   environmentalScripts: []
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3446,9 +3446,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
           "dev": true
         }
       }
@@ -6770,8 +6770,7 @@
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                   "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "gauge": {
                   "version": "2.6.0",
@@ -6817,7 +6816,6 @@
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
-                      "optional": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -6829,7 +6827,6 @@
                           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                           "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                           "dev": true,
-                          "optional": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
                           },
@@ -6838,8 +6835,7 @@
                               "version": "1.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                              "dev": true,
-                              "optional": true
+                              "dev": true
                             }
                           }
                         },
@@ -6848,7 +6844,6 @@
                           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
-                          "optional": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
                           },
@@ -6857,8 +6852,7 @@
                               "version": "1.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                              "dev": true,
-                              "optional": true
+                              "dev": true
                             }
                           }
                         }
@@ -8147,7 +8141,6 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9021,8 +9014,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.2.0",
@@ -12279,7 +12271,6 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
           "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "0.9.x"
           }
@@ -12346,8 +12337,7 @@
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
           "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "0.10.1",


### PR DESCRIPTION
livereload causes timeout in Zap tests (and [cypress by the sound of it](#207)) which causes tests to fail.

Most of the noise in this commit is from `npm run precommit`, but the important changes means we can add any environmental scripts (script tags) to the environment specific files only (see config/env/all.js for example). In the production environment file I've simply left the `environmentalScripts` array empty. Possibly we could do like wise in the test environment file as well, that would fix #207

These changes are essential (or at least no livereload) for [purpleteam](https://gitlab.com/purpleteam-labs) testing NodeGoat.

