### PR TITLE
Fix repeated dbResets so tests run faster

### DIFF
--- a/test/e2e/integration/allocations_spec.js
+++ b/test/e2e/integration/allocations_spec.js
@@ -5,10 +5,6 @@ describe('/allocations behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/benefits_spec.js
+++ b/test/e2e/integration/benefits_spec.js
@@ -5,10 +5,6 @@ describe('/login behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/contributions_spec.js
+++ b/test/e2e/integration/contributions_spec.js
@@ -5,10 +5,6 @@ describe('/contributions behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/login_spec.js
+++ b/test/e2e/integration/login_spec.js
@@ -5,10 +5,6 @@ describe('/login behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/logout_spec.js
+++ b/test/e2e/integration/logout_spec.js
@@ -5,10 +5,6 @@ describe('/logout behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   it('Should redirect if the user has not logged in', () => {
     cy.visitPage('/logout')
     cy.url().should('include', 'login')

--- a/test/e2e/integration/memos_spec.js
+++ b/test/e2e/integration/memos_spec.js
@@ -5,10 +5,6 @@ describe('/memos behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/profile_spec.js
+++ b/test/e2e/integration/profile_spec.js
@@ -5,10 +5,6 @@ describe('/profile behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/signup_spec.js
+++ b/test/e2e/integration/signup_spec.js
@@ -5,10 +5,6 @@ describe('/signup behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/plugins/index.js
+++ b/test/e2e/plugins/index.js
@@ -8,10 +8,16 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
+const { port, hostName } = require('../../../config/env/all')
+
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+
+  config.baseUrl = `http://${hostName}:${port}`
+
+  return config
 }

--- a/test/e2e/support/commands.js
+++ b/test/e2e/support/commands.js
@@ -1,7 +1,5 @@
-const { port, hostName } = require('../../../config/env/all')
-
 Cypress.Commands.add('signIn', (usr, pw) => {
-  cy.visit(`http://${hostName}:${port}/login`)
+  cy.visitPage('/login')
   cy.get('#userName').type(usr)
   cy.get('#password').type(pw)
   cy.get('[type="submit"]').click()
@@ -22,7 +20,7 @@ Cypress.Commands.add('userSignIn', () => {
 })
 
 Cypress.Commands.add('visitPage', (path = '/', config = {}) => {
-  cy.visit(`http://${hostName}:${port}${path}`, config)
+  cy.visit(path, config)
 })
 
 Cypress.Commands.add('dbReset', () => {


### PR DESCRIPTION
The Cypress tests currently spend a lot of time resetting the database between each spec. Currently the database is reset **3x per spec** (except for the specs that don't affect the database).

Part of this is down to [Cypress bug 2777](https://github.com/cypress-io/cypress/issues/2777), which makes the `before` hook run twice if a baseUrl hasn't been set. This is fixed by setting the appropriate baseUrl in [test/e2e/plugins/index.js](https://github.com/OWASP/NodeGoat/pull/218/files#diff-9d8a21d2399ec441f4808cf17429646000f13c25a40c80d91264bd1f41d2d6c9) and changing `visitPage` to use relative URLs ([test/e2e/support/commands.js](https://github.com/OWASP/NodeGoat/pull/218/files#diff-ce50fee3222de361e9f6afce9f67cb541d0de1edf2433d28deda0244e7300913)).

Also, the eight specs that call `cy.dbReset()` do so before and after they are run. One spec resets the database after it finishes, and the next immediately resets again before running. The recommendation from the Cypress team is to [clean up state before tests](https://docs.cypress.io/guides/references/best-practices.html#Using-after-or-afterEach-hooks) rather than after. This PR removes the `after(() => {cy.dbReset})` hooks from all tests.

On Travis CI these changes cut about 50 seconds off each Cypress run.
