### PR TITLE
Insecure Default - mongodb connection string

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -1,10 +1,6 @@
 // default app configuration
 const port = process.env.PORT || 4000;
-let db = process.env.MONGOLAB_URI || process.env.MONGODB_URI;
-
-if (!db) {
-    db = 'mongodb://localhost:27017/nodegoat';
-}
+let db = process.env.MONGODB_URI || "mongodb://localhost:27017/nodegoat";
 
 module.exports = {
     port,

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -3,7 +3,7 @@ const port = process.env.PORT || 4000;
 let db = process.env.MONGOLAB_URI || process.env.MONGODB_URI;
 
 if (!db) {
-    db = process.env.NODE_ENV === 'test' ? 'mongodb://localhost:27017/nodegoat' : 'mongodb://nodegoat:owasp@nodegoat-cluster-shard-00-00.zkkl5.mongodb.net:27017,nodegoat-cluster-shard-00-01.zkkl5.mongodb.net:27017,nodegoat-cluster-shard-00-02.zkkl5.mongodb.net:27017/nodegoat?ssl=true&replicaSet=atlas-qajmlr-shard-0&authSource=admin&retryWrites=true&w=majority';
+    db = 'mongodb://localhost:27017/nodegoat';
 }
 
 module.exports = {


### PR DESCRIPTION
Hi there,
Came across this issue when I was setting this up in Azure.
If there is no MONDODB_URI environment variable then the application will default to the Atlas nodegoat database.
I am unaware of the intent, but by having this default behavior it effectively makes the OWASP nodegoat database a shared database with other unsuspecting hosts.
This is bad news owing to some of the malicious stuff that is possible on this application - of note is the XSS currently being executed by the username of userid 2 on this database. Right now it is just an alertbox of document.cookies but would not be great if someone was to put their own malicious script in its place