### PR TITLE
Add GitHub Actions "E2E Test" workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@ Dockerfile
 docker-compose.yml
 .dockerignore
 .git
+.github
 .gitignore

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,46 @@
+name: E2E Test
+on: [push, pull_request]
+
+jobs:
+  e2e-test:
+    name: Node.js
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["10.x", "12.x", "14.x"]
+
+    steps:
+      - name: Checkout https://github.com/${{ github.repository }}@${{ github.ref }}
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Use cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            ~/.cache
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-E2E-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm run cy:verify
+
+      - name: Start MongoDB
+        run: |
+          docker run -d -p 27017:27017 mongo:4.0
+          timeout 60s bash -c 'until nc -z -w 2 localhost 27017 && echo MongoDB ready; do sleep 2; done'
+
+      - name: Run E2E test suite
+        run: |
+          NODE_ENV=test npm start -- --silent &
+          npm run test:ci

--- a/test/e2e/integration/allocations_spec.js
+++ b/test/e2e/integration/allocations_spec.js
@@ -5,10 +5,6 @@ describe('/allocations behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/benefits_spec.js
+++ b/test/e2e/integration/benefits_spec.js
@@ -5,10 +5,6 @@ describe('/login behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/contributions_spec.js
+++ b/test/e2e/integration/contributions_spec.js
@@ -5,10 +5,6 @@ describe('/contributions behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/login_spec.js
+++ b/test/e2e/integration/login_spec.js
@@ -5,10 +5,6 @@ describe('/login behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/logout_spec.js
+++ b/test/e2e/integration/logout_spec.js
@@ -5,10 +5,6 @@ describe('/logout behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   it('Should redirect if the user has not logged in', () => {
     cy.visitPage('/logout')
     cy.url().should('include', 'login')

--- a/test/e2e/integration/memos_spec.js
+++ b/test/e2e/integration/memos_spec.js
@@ -5,10 +5,6 @@ describe('/memos behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/profile_spec.js
+++ b/test/e2e/integration/profile_spec.js
@@ -5,10 +5,6 @@ describe('/profile behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/signup_spec.js
+++ b/test/e2e/integration/signup_spec.js
@@ -5,10 +5,6 @@ describe('/signup behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/plugins/index.js
+++ b/test/e2e/plugins/index.js
@@ -8,10 +8,16 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
+const { port, hostName } = require('../../../config/env/all')
+
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+
+  config.baseUrl = `http://${hostName}:${port}`
+
+  return config
 }

--- a/test/e2e/support/commands.js
+++ b/test/e2e/support/commands.js
@@ -1,7 +1,5 @@
-const { port, hostName } = require('../../../config/env/all')
-
 Cypress.Commands.add('signIn', (usr, pw) => {
-  cy.visit(`http://${hostName}:${port}/login`)
+  cy.visitPage('/login')
   cy.get('#userName').type(usr)
   cy.get('#password').type(pw)
   cy.get('[type="submit"]').click()
@@ -22,7 +20,7 @@ Cypress.Commands.add('userSignIn', () => {
 })
 
 Cypress.Commands.add('visitPage', (path = '/', config = {}) => {
-  cy.visit(`http://${hostName}:${port}${path}`, config)
+  cy.visit(path, config)
 })
 
 Cypress.Commands.add('dbReset', () => {


### PR DESCRIPTION
This PR implements a GitHub Actions workflow to run the Cypress E2E test suite on pushes and pull requests.

It's equivalent to the current Travis config in the master branch. The tests are run against Node.js 10, 12 and 14, as they're the LTS releases as of 2021.

The PR also includes the #218 change, which makes the Cypress tests run ~50s faster.

All the actions used are created and maintained by GitHub, so this setup can be used in `Settings -> Actions`:

![actions-settings](https://user-images.githubusercontent.com/42620235/104847192-84408a80-58d6-11eb-8b25-323b211e18d5.png)

Since this PR is adding the workflow it doesn't exist in the source repo yet, so isn't included in the checks below. Here's the run for the c57fd29 commit in my fork so you can see what it does: https://github.com/rcowsill/NodeGoat/actions/runs/491755966. BTW: I have `ACTIONS_STEP_DEBUG` enabled in my fork; the purple `##[debug]` lines will be hidden by default. Also this workflow has been tested on Ubuntu 20.04 already, so no further update is needed when ubuntu-latest is next updated.