### PR TITLE
Fix crash when research page server-side request fails

### DIFF
--- a/app/routes/research.js
+++ b/app/routes/research.js
@@ -13,7 +13,7 @@ function ResearchHandler(db) {
 
         if (req.query.symbol) {
             const url = req.query.url + req.query.symbol;
-            return needle.get(url, (error, newResponse) => {
+            return needle.get(url, (error, newResponse, body) => {
                 if (!error && newResponse.statusCode === 200) {
                     res.writeHead(200, {
                         "Content-Type": "text/html"
@@ -21,7 +21,9 @@ function ResearchHandler(db) {
                 }
                 res.write("<h1>The following is the stock information you requested.</h1>\n\n");
                 res.write("\n\n");
-                res.write(newResponse.body);
+                if (body) {
+                    res.write(body);
+                }
                 return res.end();
             });
         }

--- a/app/routes/research.js
+++ b/app/routes/research.js
@@ -1,5 +1,5 @@
 const ResearchDAO = require("../data/research-dao").ResearchDAO;
-const needle = require('needle');
+const needle = require("needle");
 const {
     environmentalScripts
 } = require("../../config/config");
@@ -14,12 +14,13 @@ function ResearchHandler(db) {
         if (req.query.symbol) {
             const url = req.query.url + req.query.symbol;
             return needle.get(url, (error, newResponse) => {
-                if (!error && newResponse.statusCode == 200)
+                if (!error && newResponse.statusCode === 200) {
                     res.writeHead(200, {
-                        'Content-Type': 'text/html'
+                        "Content-Type": "text/html"
                     });
-                res.write('<h1>The following is the stock information you requested.</h1>\n\n');
-                res.write('\n\n');
+                }
+                res.write("<h1>The following is the stock information you requested.</h1>\n\n");
+                res.write("\n\n");
                 res.write(newResponse.body);
                 return res.end();
             });


### PR DESCRIPTION
Fix for #225

The first commit fixes jshint warnings in the file; using doublequotes, semicolons and strict equality. The second commit contains the fix.