### PR TITLE
Fix path traversal vulnerability

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,9 +5,7 @@ const ContributionsHandler = require("./contributions");
 const AllocationsHandler = require("./allocations");
 const MemosHandler = require("./memos");
 const ResearchHandler = require("./research");
-const {
-    environmentalScripts
-} = require("../../config/config");
+const tutorialRouter = require("./tutorial");
 const ErrorHandler = require("./error").errorHandler;
 
 const index = (app, db) => {
@@ -74,24 +72,11 @@ const index = (app, db) => {
         return res.redirect(req.query.url);
     });
 
-    // Handle redirect for learning resources link
-    app.get("/tutorial", (req, res) => {
-        return res.render("tutorial/a1", {
-            environmentalScripts
-        });
-    });
-
-    app.get("/tutorial/:page", (req, res) => {
-        const {
-            page
-        } = req.params;
-        return res.render(`tutorial/${page}`, {
-            environmentalScripts
-        });
-    });
-
     // Research Page
     app.get("/research", isLoggedIn, researchHandler.displayResearch);
+
+    // Mount tutorial router
+    app.use("/tutorial", tutorialRouter);
 
     // Error handling middleware
     app.use(ErrorHandler);

--- a/app/routes/tutorial.js
+++ b/app/routes/tutorial.js
@@ -12,14 +12,28 @@ router.get("/", (req, res) => {
     });
 });
 
-router.get("/:page", (req, res) => {
-    "use strict";
-    const {
-        page
-    } = req.params;
-    return res.render(`tutorial/${page}`, {
-        environmentalScripts
+const pages = [
+    "a1",
+    "a2",
+    "a3",
+    "a4",
+    "a5",
+    "a6",
+    "a7",
+    "a8",
+    "a9",
+    "a10",
+    "redos",
+    "ssrf"
+];
+
+for(const page of pages) {
+    router.get(`/${page}`, (req, res) => {
+        "use strict";
+        return res.render(`tutorial/${page}`, {
+            environmentalScripts
+        });
     });
-});
+}
 
 module.exports = router;

--- a/app/routes/tutorial.js
+++ b/app/routes/tutorial.js
@@ -1,0 +1,25 @@
+const express = require("express");
+const {
+    environmentalScripts
+} = require("../../config/config");
+
+const router = express.Router();
+
+router.get("/", (req, res) => {
+    "use strict";
+    return res.render("tutorial/a1", {
+        environmentalScripts
+    });
+});
+
+router.get("/:page", (req, res) => {
+    "use strict";
+    const {
+        page
+    } = req.params;
+    return res.render(`tutorial/${page}`, {
+        environmentalScripts
+    });
+});
+
+module.exports = router;


### PR DESCRIPTION
The first commit moves the tutorial routes out of `routes/index.js` and into a separate router. This is to avoid cluttering the top-level route setup with the tutorial routing code. The tutorial is effectively a microsite alongside the main application, so it seems reasonable to split it out like this.

The second commit replaces the `/tutorial/:page` route with individual routes for each page.

Currently the set of allowed pages is just listed explicitly. I considered generating the page list from the filesystem or using [HenrikJoreteg/semi-static](https://github.com/HenrikJoreteg/semi-static), but that would require moving the templates around to avoid serving the layout template.

Fixes #232