### PR TITLE
Fix Mongo version to before OP_QUERY deprecation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "4000:4000"
 
   mongo:
-    image: mongo:latest
+    image: mongo:4.0
     user: mongodb
     expose:
       - 27017


### PR DESCRIPTION
OP_QUERY was deprecated in 5.0. Fix Mongo version to 4.0 instead of "latest".