### PR TITLE
doc: annotate server.js with extra info regarding session and static …

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,6 +116,8 @@ MongoClient.connect(db, (err, db) => {
     app.engine(".html", consolidate.swig);
     app.set("view engine", "html");
     app.set("views", `${__dirname}/app/views`);
+    // Fix for A5 - Security MisConfig
+    // TODO: make sure assets are declared before app.use(session())
     app.use(express.static(`${__dirname}/app/assets`));
 
 


### PR DESCRIPTION
Express uses a middleware system to execute code, modify requests and responses, and perform other tasks whenever a network action takes place. The order you define these middleware matters. From the [express documentation](https://expressjs.com/en/guide/writing-middleware.html):

> The order of middleware loading is important: middleware functions that are loaded first are also executed first.
> 

*This* is the problem we can look for. Here's an example of what not to do:

```javascript
app.use(session());
app.use(express.static(__dirname + '/public'));
```

In this case, the session handler is initialized before returning a static asset. 

Instead, we want to confirm that the static asset middleware, `express.static` is set prior to the `session` middleware.

```javascript
app.use(express.static(__dirname + '/public'));
// any other middelware
app.use(session());
```

This will serve static assets as expected, but not apply the session middleware to them since it is defined later.

## Links

- https://twitter.com/vhmth/status/1633631115113103362?s=20
- https://www.loom.com/blog/march-7-incident-update