### PR TITLE
fix(security): redact secrets from config startup log (CWE-532)

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -9,7 +9,39 @@ const envConf = require(path.resolve(__dirname + "/../config/env/" + finalEnv.to
 
 const config = { ...allConf, ...envConf };
 
-console.log(`Current Config:`);
-console.log(util.inspect(config, false, null));
+function redactMongoConnectionString(uri) {
+    if (typeof uri !== "string" || !uri) {
+        return uri;
+    }
+    try {
+        const parsed = new URL(uri);
+        if (parsed.username || parsed.password) {
+            parsed.username = "***";
+            parsed.password = "***";
+        }
+        return parsed.toString();
+    } catch (e) {
+        return "[redacted-db-uri]";
+    }
+}
+
+function sanitizeConfigForLog(cfg) {
+    const sanitized = { ...cfg };
+    if (Object.prototype.hasOwnProperty.call(sanitized, "cookieSecret")) {
+        sanitized.cookieSecret = "[redacted]";
+    }
+    if (Object.prototype.hasOwnProperty.call(sanitized, "cryptoKey")) {
+        sanitized.cryptoKey = "[redacted]";
+    }
+    if (Object.prototype.hasOwnProperty.call(sanitized, "db")) {
+        sanitized.db = redactMongoConnectionString(sanitized.db);
+    }
+    return sanitized;
+}
+
+if (process.env.NODE_ENV === "development" && process.env.DEBUG_CONFIG) {
+    console.log("Current Config:");
+    console.log(util.inspect(sanitizeConfigForLog(config), false, null));
+}
 
 module.exports = config;


### PR DESCRIPTION
## Summary

`config/config.js` logs the full configuration object to stdout on every startup, exposing `cookieSecret`, `cryptoKey`, and the MongoDB connection URI (which may contain credentials) to anyone with access to application logs.

This is CWE-532 (Insertion of Sensitive Information into Log File).

## Root Cause

Lines 12-13 of `config/config.js` unconditionally call `console.log(util.inspect(config))`, dumping the entire config including secrets.

## Fix

- Gate config logging behind `NODE_ENV === 'development'` AND `DEBUG_CONFIG` environment variable
- When logging is enabled, redact `cookieSecret`, `cryptoKey`, and credentials in the `db` connection string

Fixes #390


Made with [Cursor](https://cursor.com)