### PR TITLE
Fix double callback bug in allocations-dao.js

### DIFF
--- a/app/data/allocations-dao.js
+++ b/app/data/allocations-dao.js
@@ -48,9 +48,9 @@ const AllocationsDAO = function(db){
 
                     return callback(null, allocations);
                 });
+            } else {
+                return callback(err, null);
             }
-
-            return callback(err, null);
         });
     };
 


### PR DESCRIPTION
## Summary

- **Fix double callback in `allocations-dao.js` `update` method.** After `allocationsCol.update()` completes successfully, execution falls through to `return callback(err, null)` on line 53 before the async `getUserById` call finishes, firing the callback twice — once with `(null, null)` and again with `(null, allocations)`.
- Wrapped the error callback in an `else` branch so it only fires when there IS an error, matching the pattern used in `contributions-dao.js`.

## The Bug

In the `update` method, the callback on line 53 ran **unconditionally** after `allocationsCol.update()` completed. On success:

1. Code enters `if (!err)` and calls `userDAO.getUserById(...)` (async)
2. Before `getUserById` completes, execution falls through to `callback(null, null)` — first (incorrect) callback
3. When `getUserById` finishes, `callback(null, allocations)` fires — second callback

This double invocation can cause double HTTP responses, "headers already sent" crashes, and corrupted client-side state.

## The Fix

```diff
-            }
-
-            return callback(err, null);
+            } else {
+                return callback(err, null);
+            }
```

## Test plan

- [ ] Verify `update` calls callback exactly once on successful allocation update
- [ ] Verify `update` calls callback with error on failed allocation update
- [ ] Verify no "headers already sent" errors in server logs during allocation updates


Made with [Cursor](https://cursor.com)