### PR TITLE
Fix isAdminUserMiddleware ignoring DB errors

### DIFF
--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -25,6 +25,7 @@ function SessionHandler(db) {
     this.isAdminUserMiddleware = (req, res, next) => {
         if (req.session.userId) {
             return userDAO.getUserById(req.session.userId, (err, user) => {
+               if (err) return next(err);
                return user && user.isAdmin ? next() : res.redirect("/login");
             });
         }


### PR DESCRIPTION
## Summary

- **Bug:** `isAdminUserMiddleware` in `app/routes/session.js` calls `userDAO.getUserById` with a callback that receives `(err, user)` but never checks `err`. If the database is down or returns an error, the middleware silently treats the request as "not admin" and redirects to `/login` instead of surfacing the actual error.
- **Fix:** Added an `if (err) return next(err);` check in the callback before evaluating the user, consistent with the error-handling pattern used elsewhere in the same file (e.g., line 267).

## Test plan

- [ ] Verify that when the DB returns an error, the middleware calls `next(err)` and Express's error handler is invoked
- [ ] Verify that normal admin/non-admin flow still works correctly (admin gets through, non-admin is redirected)
- [ ] Run existing test suite (`npm test`)


Made with [Cursor](https://cursor.com)