### PR TITLE
fix: resolve N+1 query in allocations getByUserIdAndThreshold

### DIFF
--- a/app/data/allocations-dao.js
+++ b/app/data/allocations-dao.js
@@ -87,24 +87,24 @@ const AllocationsDAO = function(db){
             if (err) return callback(err, null);
             if (!allocations.length) return callback("ERROR: No allocations found for the user", null);
 
-            let doneCounter = 0;
-            const userAllocations = [];
+            const userIds = allocations.map(alloc => alloc.userId);
 
-            allocations.forEach( alloc => {
-                userDAO.getUserById(alloc.userId, (err, user) => {
-                    if (err) return callback(err, null);
+            userDAO.getUsersByIds(userIds, (err, users) => {
+                if (err) return callback(err, null);
 
-                    alloc.userName = user.userName;
-                    alloc.firstName = user.firstName;
-                    alloc.lastName = user.lastName;
+                const usersById = {};
+                users.forEach(user => { usersById[user._id] = user; });
 
-                    doneCounter += 1;
-                    userAllocations.push(alloc);
-
-                    if (doneCounter === allocations.length) {
-                        callback(null, userAllocations);
+                allocations.forEach(alloc => {
+                    const user = usersById[parseInt(alloc.userId)];
+                    if (user) {
+                        alloc.userName = user.userName;
+                        alloc.firstName = user.firstName;
+                        alloc.lastName = user.lastName;
                     }
                 });
+
+                callback(null, allocations);
             });
         });
     };

--- a/app/data/user-dao.js
+++ b/app/data/user-dao.js
@@ -100,6 +100,13 @@ function UserDAO(db) {
         }, callback);
     };
 
+    this.getUsersByIds = (userIds, callback) => {
+        const parsedIds = [...new Set(userIds.map(id => parseInt(id)))];
+        usersCol.find({
+            _id: { $in: parsedIds }
+        }).toArray(callback);
+    };
+
     this.getUserByUserName = (userName, callback) => {
         usersCol.findOne({
             userName: userName


### PR DESCRIPTION
## Summary

- **Fix N+1 database queries** in `allocations-dao.js` `getByUserIdAndThreshold`: replaced the per-allocation `getUserById` loop (one MongoDB round-trip per allocation) with a single batched `getUsersByIds` call using `$in`, reducing DB round-trips from N to 1.
- **Added `getUsersByIds`** to `user-dao.js` — accepts an array of user IDs, deduplicates them, and fetches all matching users in one query.

## Test plan

- [ ] Verify `getByUserIdAndThreshold` returns correct user details (`userName`, `firstName`, `lastName`) on each allocation
- [ ] Confirm only a single `users` collection query is issued regardless of allocation count
- [ ] Check edge case where multiple allocations reference the same `userId` (no duplicate fetches)

Made with [Cursor](https://cursor.com)