### PR TITLE
docs: add scan demo note

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,7 @@ Here are the amazing [contributors](https://github.com/OWASP/NodeGoat/graphs/con
 ## License
 
 Code licensed under the [Apache License v2.0.](http://www.apache.org/licenses/LICENSE-2.0)
+
+---
+
+Demo note: this fork includes a small documentation-only change to drive external scan workflow validation.


### PR DESCRIPTION
## Summary
- Add a small documentation note used to drive demo scan workflow validation in this fork.
- Keep application code unchanged while we run full-project security scans against repo history.
