### PR TITLE
[Security Fix] SAST: Insecure Direct Object Reference: any logged-in user can view any other user'...

### DIFF
--- a/app/routes/allocations.js
+++ b/app/routes/allocations.js
@@ -9,13 +9,16 @@ function AllocationsHandler(db) {
     const allocationsDAO = new AllocationsDAO(db);
 
     this.displayAllocations = (req, res, next) => {
-        /*
-        // Fix for A4 Insecure DOR -  take user id from session instead of from URL param
-        const { userId } = req.session;
-        */
-        const {
-            userId
-        } = req.params;
+        // Fix for A4 Insecure DOR - take user id from session instead of trusting the URL param.
+        // Reject the request if the URL param does not match the authenticated session user.
+        const sessionUserId = req.session && req.session.userId;
+        const paramUserId = req.params.userId;
+
+        if (!sessionUserId || parseInt(paramUserId, 10) !== parseInt(sessionUserId, 10)) {
+            return res.status(403).send("Forbidden");
+        }
+
+        const userId = sessionUserId;
         const {
             threshold
         } = req.query;


### PR DESCRIPTION
## Security Fix

**Type:** SAST
**Generated by:** AI-Powered Fix Generator
**Finding:** Insecure Direct Object Reference: any logged-in user can view any other user's allocations by changing the userId path parameter.
**Rule:** claude-auth-idor-allocations (oogway-scanner)
**File:** `app/routes/allocations.js` (line 12)
**Severity:** HIGH

### Explanation
The handler trusted the `userId` path parameter to look up allocations, allowing any authenticated user to view another user's portfolio simply by changing the URL (classic IDOR). The fix enforces that the `userId` in the URL must match the authenticated user's `userId` from the server-side session. If the requested `userId` does not match the session user, the request is rejected with HTTP 403. The session `userId` is used to perform the DAO lookup so that the URL parameter cannot be used to escalate access.

### Changes
- `app/routes/allocations.js`: Enforce that the requested userId matches the authenticated session user, preventing IDOR. Use the session userId for the DAO lookup.

### Test Suggestions
- Authenticated user requesting GET /allocations/<their own userId> succeeds and renders their allocations.
- Authenticated user requesting GET /allocations/<other userId> receives 403 Forbidden and no data is leaked.
- Unauthenticated request to GET /allocations/:userId is rejected (403 or redirected by upstream auth middleware).
- Existing threshold query string behavior is preserved for the legitimate user.

### Breaking Changes
- Requests to /allocations/:userId where the path userId does not equal the session userId now return HTTP 403 instead of returning another user's allocations. Any client code or links that relied on viewing arbitrary users' allocations via this endpoint will break (this is the intended security fix).