### PR TITLE
[Security Fix] SAST: Authenticated RCE via eval() of request body fields preTax/afterTax/roth.

### DIFF
--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -27,11 +27,10 @@ function ContributionsHandler(db) {
 
     this.handleContributionsUpdate = (req, res, next) => {
 
-        /*jslint evil: true */
-        // Insecure use of eval() to parse inputs
-        const preTax = eval(req.body.preTax);
-        const afterTax = eval(req.body.afterTax);
-        const roth = eval(req.body.roth);
+        // Fix for A1 - SSJS Injection attacks - parse inputs as integers instead of eval()
+        const preTax = parseInt(req.body.preTax, 10);
+        const afterTax = parseInt(req.body.afterTax, 10);
+        const roth = parseInt(req.body.roth, 10);
 
         /*
         //Fix for A1 -1 SSJS Injection attacks - uses alternate method to eval


### PR DESCRIPTION
## Security Fix

**Type:** SAST
**Generated by:** AI-Powered Fix Generator
**Finding:** Authenticated RCE via eval() of request body fields preTax/afterTax/roth.
**Rule:** claude-injection-eval-contributions (oogway-scanner)
**File:** `app/routes/contributions.js` (line 31)
**Severity:** HIGH

### Explanation
The handler passed `req.body.preTax`, `req.body.afterTax`, and `req.body.roth` directly to `eval()`, allowing any authenticated user to execute arbitrary JavaScript on the server (RCE). The fix replaces `eval()` with `parseInt(..., 10)`, which safely coerces the input strings to integers. Existing downstream validation (`isNaN`, negative checks, 30% cap) continues to work unchanged because it already operates on numeric values.

### Changes
- `app/routes/contributions.js`: Replace eval() of user-controlled request body fields with parseInt() to prevent server-side JavaScript injection / authenticated RCE.

### Test Suggestions
- POST /contributions with numeric strings (e.g., preTax=10, afterTax=5, roth=5) and verify the update succeeds.
- POST /contributions with non-numeric values (e.g., preTax="abc") and verify the response renders the 'Invalid contribution percentages' error rather than executing code.
- POST /contributions with a malicious payload such as preTax="require('child_process').execSync('id')" and confirm it is treated as NaN and rejected, with no command execution.
- POST /contributions with values summing above 30 and confirm the 30% cap error is returned.

### Breaking Changes
- Inputs that previously relied on eval() semantics (e.g., expressions like '5+5') will no longer be evaluated; only leading-integer parsing is supported via parseInt.