### PR TITLE
[Security Fix] SAST: Server-Side Request Forgery: server fetches arbitrary attacker-controlled URL...

### DIFF
--- a/app/routes/research.js
+++ b/app/routes/research.js
@@ -12,7 +12,10 @@ function ResearchHandler(db) {
     this.displayResearch = (req, res) => {
 
         if (req.query.symbol) {
-            const url = req.query.url + req.query.symbol;
+            // Fix SSRF: do not allow the client to control the upstream URL.
+            // Pin the host to a trusted endpoint and only allow the symbol
+            // (safely encoded) as user-controlled input.
+            const url = "https://www.google.com/finance?q=" + encodeURIComponent(req.query.symbol);
             return needle.get(url, (error, newResponse, body) => {
                 if (!error && newResponse.statusCode === 200) {
                     res.writeHead(200, {


### PR DESCRIPTION
## Security Fix

**Type:** SAST
**Generated by:** AI-Powered Fix Generator
**Finding:** Server-Side Request Forgery: server fetches arbitrary attacker-controlled URL and returns the response body.
**Rule:** claude-ssrf-research-url (oogway-scanner)
**File:** `app/routes/research.js` (line 13)
**Severity:** HIGH

### Explanation
The previous handler concatenated an attacker-controlled `url` query parameter with `symbol` and used `needle.get` to fetch it, then wrote the raw response body back to the client. This is a classic Server-Side Request Forgery (SSRF) with response-body reflection: an attacker could point the server at internal services (cloud metadata endpoints, internal admin APIs, localhost services, etc.) and exfiltrate the responses through this endpoint.

The fix removes the user-controlled URL entirely and pins the outbound request to a fixed, trusted upstream host. Only the `symbol` parameter remains user-controlled, and it is URL-encoded before being appended so it cannot break out of the path/host. Existing behavior (rendering the research page when no symbol is provided, returning the upstream HTML when one is) is preserved for the legitimate use case.

### Changes
- `app/routes/research.js`: Replace attacker-controlled URL concatenation with a fixed upstream host and URL-encode the symbol to prevent SSRF.

### Test Suggestions
- GET /research?symbol=AAPL should still return the stock-information HTML wrapper.
- GET /research?symbol=AAPL&url=http://169.254.169.254/latest/meta-data/ must NOT contact 169.254.169.254 (verify via outbound network mock).
- GET /research?symbol=../../etc/passwd should be safely URL-encoded into the upstream path and not traverse the URL structure.
- GET /research with no symbol should continue to render the research view.

### Breaking Changes
- The `url` query parameter is no longer honored; the upstream host for stock lookups is now fixed to a hardcoded allow-listed endpoint.