### PR TITLE
[Security Fix] SAST: NoSQL/JS injection via unsanitized `threshold` interpolated into a Mongo $whe...

### DIFF
--- a/app/data/allocations-dao.js
+++ b/app/data/allocations-dao.js
@@ -60,23 +60,18 @@ const AllocationsDAO = function(db){
         const searchCriteria = () => {
 
             if (threshold) {
-                /*
-                // Fix for A1 - 2 NoSQL Injection - escape the threshold parameter properly
-                // Fix this NoSQL Injection which doesn't sanitze the input parameter 'threshold' and allows attackers
-                // to inject arbitrary javascript code into the NoSQL query:
-                // 1. 0';while(true){}'
-                // 2. 1'; return 1 == '1
-                // Also implement fix in allocations.html for UX.                             
+                // Fix for A1 - 2 NoSQL Injection - validate and coerce the threshold
+                // parameter to an integer before using it in the query so that attackers
+                // cannot inject arbitrary JavaScript into a $where clause.
                 const parsedThreshold = parseInt(threshold, 10);
-                
-                if (parsedThreshold >= 0 && parsedThreshold <= 99) {
-                    return {$where: `this.userId == ${parsedUserId} && this.stocks > ${parsedThreshold}`};
+
+                if (Number.isInteger(parsedThreshold) && parsedThreshold >= 0 && parsedThreshold <= 99) {
+                    return {
+                        userId: parsedUserId,
+                        stocks: { $gt: parsedThreshold }
+                    };
                 }
-                throw `The user supplied threshold: ${parsedThreshold} was not valid.`;
-                */
-                return {
-                    $where: `this.userId == ${parsedUserId} && this.stocks > '${threshold}'`
-                };
+                throw `The user supplied threshold: ${threshold} was not valid.`;
             }
             return {
                 userId: parsedUserId


### PR DESCRIPTION
## Security Fix

**Type:** SAST
**Generated by:** AI-Powered Fix Generator
**Finding:** NoSQL/JS injection via unsanitized `threshold` interpolated into a Mongo $where clause.
**Rule:** claude-injection-nosql-where (oogway-scanner)
**File:** `app/data/allocations-dao.js` (line 70)
**Severity:** HIGH

### Explanation
The original code interpolated the user-supplied `threshold` value directly into a MongoDB `$where` clause as a JavaScript string, allowing an attacker to inject arbitrary JS (e.g. `0';while(true){}'` for DoS or `1'; return 1 == '1` to bypass filtering). MongoDB executes `$where` as JavaScript on the server, so this is a critical injection sink.

The fix removes the `$where` operator entirely and instead uses a structured query with `userId` equality and `stocks: { $gt: parsedThreshold }`. The threshold is validated with `parseInt` and bounds-checked (0–99) before use; invalid values throw, mirroring the previously commented-out safe behavior. This preserves the original semantics (find allocations for the given user whose stocks exceed the threshold) while eliminating the JS-injection vector and also avoids the performance penalty of `$where`.

### Changes
- `app/data/allocations-dao.js`: Replace the unsanitized $where JavaScript expression with a validated integer threshold and a safe structured query using $gt, eliminating the NoSQL/JS injection vector.

### Test Suggestions
- GET /allocations/:userId?threshold=50 returns allocations where stocks > 50 for that user.
- GET /allocations/:userId without threshold still returns all allocations for that user.
- GET /allocations/:userId?threshold=0';while(true){}' is rejected (throws validation error) and does not hang the server.
- GET /allocations/:userId?threshold=-1 and ?threshold=100 are rejected as invalid.
- GET /allocations/:userId?threshold=abc is rejected as invalid.

### Breaking Changes
- Invalid or out-of-range threshold values (non-integer, <0, or >99) now throw instead of being silently passed through to a $where clause; callers relying on those previously injectable inputs will receive an error.