### PR TITLE
[Security Fix] SAST: Authenticated RCE via eval() applied to request body fields preTax/afterTax/r...

### DIFF
--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -27,11 +27,10 @@ function ContributionsHandler(db) {
 
     this.handleContributionsUpdate = (req, res, next) => {
 
-        /*jslint evil: true */
-        // Insecure use of eval() to parse inputs
-        const preTax = eval(req.body.preTax);
-        const afterTax = eval(req.body.afterTax);
-        const roth = eval(req.body.roth);
+        // Fix for A1 - SSJS Injection: parse inputs as integers instead of eval()
+        const preTax = parseInt(req.body.preTax, 10);
+        const afterTax = parseInt(req.body.afterTax, 10);
+        const roth = parseInt(req.body.roth, 10);
 
         /*
         //Fix for A1 -1 SSJS Injection attacks - uses alternate method to eval


### PR DESCRIPTION
## Security Fix

**Type:** SAST
**Generated by:** AI-Powered Fix Generator
**Finding:** Authenticated RCE via eval() applied to request body fields preTax/afterTax/roth.
**Rule:** claude-injection-eval-contributions (oogway-scanner)
**File:** `app/routes/contributions.js` (line 33)
**Severity:** HIGH

### Explanation
The handler passed `req.body.preTax`, `req.body.afterTax`, and `req.body.roth` directly to `eval()`. Because the request body is fully attacker-controlled, any authenticated user could submit a string of JavaScript (e.g. `require('child_process').execSync('...')`) and have it executed in the Node.js server process, resulting in remote code execution.

The fix replaces each `eval()` call with `parseInt(..., 10)`, which safely coerces the input to an integer. The existing downstream validations (`isNaN`, negative checks, sum-cap of 30) continue to work unchanged because they already expect numeric values, preserving all functional behavior while eliminating the injection sink.

### Changes
- `app/routes/contributions.js`: Replace eval() of user-supplied request body fields with parseInt() to prevent server-side JavaScript injection / authenticated RCE.

### Test Suggestions
- POST /contributions with preTax='10', afterTax='10', roth='10' should succeed and update contributions.
- POST /contributions with preTax='require("child_process").execSync("id")' should be rejected as invalid (NaN) and not execute any code.
- POST /contributions with preTax='-5' should return 'Invalid contribution percentages'.
- POST /contributions where preTax+afterTax+roth > 30 should return the 30% cap error.

### Breaking Changes
- Inputs that previously relied on eval()'s ability to evaluate arbitrary expressions (e.g. '5+5') will now parse only the leading integer ('5+5' becomes 5). Plain numeric strings continue to work identically.